### PR TITLE
Fix map handling in .js and .codec.js to match .base.js

### DIFF
--- a/msgpack.codec.js
+++ b/msgpack.codec.js
@@ -230,7 +230,7 @@ function encode(rv,      // @param ByteArray: result
 // inner - decoder
 function decode() { // @return Mix:
     var size, i, iz, c, num = 0,
-        sign, exp, frac, ary, hash,
+        sign, exp, frac, ary, key, hash,
         buf = _buf, type = buf[++_idx];
 
     if (type >= 0xe0) {             // Negative FixNum (111x xxxx) (-32 ~ -1)
@@ -344,17 +344,8 @@ function decode() { // @return Mix:
     case 0x80:  hash = {};
                 while (num--) {
                     // make key/value pair
-                    size = buf[++_idx] - 0xa0;
-
-                    for (ary = [], i = _idx, iz = i + size; i < iz; ) {
-                        c = buf[++i]; // lead byte
-                        ary.push(c < 0x80 ? c : // ASCII(0x00 ~ 0x7f)
-                                 c < 0xe0 ? ((c & 0x1f) <<  6 | (buf[++i] & 0x3f)) :
-                                            ((c & 0x0f) << 12 | (buf[++i] & 0x3f) << 6
-                                                              | (buf[++i] & 0x3f)));
-                    }
-                    _idx = i;
-                    hash[_toString.apply(null, ary)] = decode();
+                    key = decode();
+                    hash[key] = decode();
                 }
                 return hash;
     // 0xdd: array32, 0xdc: array16, 0x90: array

--- a/msgpack.js
+++ b/msgpack.js
@@ -245,7 +245,7 @@ function encode(rv,      // @param ByteArray: result
 // inner - decoder
 function decode() { // @return Mix:
     var size, i, iz, c, num = 0,
-        sign, exp, frac, ary, hash,
+        sign, exp, frac, ary, key, hash,
         buf = _buf, type = buf[++_idx];
 
     if (type >= 0xe0) {             // Negative FixNum (111x xxxx) (-32 ~ -1)
@@ -359,17 +359,8 @@ function decode() { // @return Mix:
     case 0x80:  hash = {};
                 while (num--) {
                     // make key/value pair
-                    size = buf[++_idx] - 0xa0;
-
-                    for (ary = [], i = _idx, iz = i + size; i < iz; ) {
-                        c = buf[++i]; // lead byte
-                        ary.push(c < 0x80 ? c : // ASCII(0x00 ~ 0x7f)
-                                 c < 0xe0 ? ((c & 0x1f) <<  6 | (buf[++i] & 0x3f)) :
-                                            ((c & 0x0f) << 12 | (buf[++i] & 0x3f) << 6
-                                                              | (buf[++i] & 0x3f)));
-                    }
-                    _idx = i;
-                    hash[_toString.apply(null, ary)] = decode();
+                    key = decode();
+                    hash[key] = decode();
                 }
                 return hash;
     // 0xdd: array32, 0xdc: array16, 0x90: array


### PR DESCRIPTION
The map handling in msgpack.js and msgpack.codec.js only handled
element keys which were of type 0xa0.  This meant any map elements
whose key was not a string of 31 bytes or less would not be imported
correctly.  msgpack.base.js handles element keys correctly, however, so
this commit modifies msgpack.js and msgpack.codec.js to correctly
process map keys.
