### PR TITLE
npm install msgpack/msgpack-javascript

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "msgpack-javascript",
+  "version": "1.0.0",
+  "description": "MessagePack: It's like JSON. but fast and small.",
+  "main": "msgpack.codec.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/msgpack/msgpack-javascript.git"
+  },
+  "homepage": "https://github.com/msgpack/msgpack-javascript"
+}


### PR DESCRIPTION
This small package.json allows developers to run adhoc installation for Node.js as below:

```sh
npm install msgpack/msgpack-javascript
```

Please note that publishing onto npmjs.org is not required.
