### PR TITLE
npm install msgpack/msgpack.codec

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "msgpack.codec",
+  "version": "1.0.0",
+  "description": "MessagePack serializer implementation for JavaScript",
+  "main": "msgpack.codec.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/msgpack/msgpack-javascript.git"
+  },
+  "homepage": "https://github.com/msgpack/msgpack-javascript"
+}


### PR DESCRIPTION
After sending the last pull request #4, I found the same name library of "msgpack-javascript" registered on npmjs: https://www.npmjs.com/package/msgpack-javascript

I've changed the name on the package.json, then.

``` sh
npm install msgpack/msgpack.codec
```
