### PR TITLE
add decodeTimestampToTimeSpec() to register custom timestamp ext handlers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,12 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
       "dev": true
     },
+    "@std-proposal/temporal": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@std-proposal/temporal/-/temporal-0.0.1.tgz",
+      "integrity": "sha512-JSYLMdoFPJww5m12oFrgGcgSR3hhGbSl7O8DV0FHvSl+R/di0zIr0+pdw7Eu7wvFtfV/udaC+xupIhGy7YGN1A==",
+      "dev": true
+    },
     "@types/base64-js": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@types/base64-js/-/base64-js-1.2.5.tgz",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "homepage": "https://msgpack.org/",
   "devDependencies": {
     "@bitjourney/check-es-version-webpack-plugin": "^1.0.2",
+    "@std-proposal/temporal": "0.0.1",
     "@types/base64-js": "^1.2.5",
     "@types/mocha": "^5.2.6",
     "@types/node": "^11.13.12",

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export {
   EXT_TIMESTAMP,
   encodeDateToTimeSpec,
   encodeTimeSpecToTimestamp,
+  decodeTimestampToTimeSpec,
   encodeTimestampExtension,
   decodeTimestampExtension,
 } from "./timestamp";

--- a/test/readme.test.ts
+++ b/test/readme.test.ts
@@ -1,5 +1,12 @@
 import { deepStrictEqual } from "assert";
-import { encode, decode } from "../src";
+import {
+  encode,
+  decode,
+  ExtensionCodec,
+  EXT_TIMESTAMP,
+  encodeTimeSpecToTimestamp,
+  decodeTimestampToTimeSpec,
+} from "../src";
 
 describe("README", () => {
   context("#synopsis", () => {
@@ -19,6 +26,43 @@ describe("README", () => {
       // encoded is an Uint8Array instance
 
       deepStrictEqual(decode(encoded), object);
+    });
+  });
+
+  context("timestamp/temporal", () => {
+    before(function() {
+      if (typeof BigInt === "undefined") {
+        this.skip();
+      }
+    });
+
+    it("overrides timestamp-ext with std-temporal", () => {
+      const Instant = require("@std-proposal/temporal").Instant;
+
+      const extensionCodec = new ExtensionCodec();
+      extensionCodec.register({
+        type: EXT_TIMESTAMP,
+        encode: (input: any) => {
+          if (input instanceof Instant) {
+            const sec = input.seconds;
+            const nsec = Number(input.nanoseconds - BigInt(sec) * BigInt(1e9));
+            return encodeTimeSpecToTimestamp({ sec, nsec });
+          } else {
+            return null;
+          }
+        },
+        decode: (data: Uint8Array) => {
+          const timeSpec = decodeTimestampToTimeSpec(data);
+          const sec = BigInt(timeSpec.sec);
+          const nsec = BigInt(timeSpec.nsec);
+          return Instant.fromEpochNanoseconds(sec * BigInt(1e9) + nsec);
+        },
+      });
+
+      const instant = Instant.fromEpochMilliseconds(Date.now());
+      const encoded = encode(instant, { extensionCodec });
+      const decoded = decode(encoded, { extensionCodec });
+      deepStrictEqual(decoded, instant);
     });
   });
 });


### PR DESCRIPTION
Also added an example to re-map timestamp-ext with [@std-proposal/temporal](https://github.com/std-proposal/temporal).