### PR TITLE
support whatwg-stream.ReadableStream as decodeAsync() input source

### DIFF
--- a/src/decodeAsync.ts
+++ b/src/decodeAsync.ts
@@ -1,17 +1,15 @@
 import { Decoder } from "./Decoder";
 import { defaultDecodeOptions, DecodeOptions } from "./decode";
-import { isReadableStream, asyncIterableFromStream } from "./utils/stream";
+import { ensureAsyncIterabe, ReadableStreamLike } from "./utils/stream";
 
 export type DecodeAsyncOptions = DecodeOptions;
 export const defaultDecodeAsyncOptions = defaultDecodeOptions;
 
-type StreamLike<T> = AsyncIterable<T> | ReadableStream<T>;
-
 export async function decodeAsync(
-  streamLike: StreamLike<Uint8Array | ArrayLike<number>>,
+  streamLike: ReadableStreamLike<Uint8Array | ArrayLike<number>>,
   options: DecodeAsyncOptions = defaultDecodeOptions,
 ): Promise<unknown> {
-  const stream = isReadableStream(streamLike) ? asyncIterableFromStream(streamLike) : streamLike;
+  const stream = ensureAsyncIterabe(streamLike);
 
   const decoder = new Decoder(
     options.extensionCodec,
@@ -25,10 +23,10 @@ export async function decodeAsync(
 }
 
 export async function* decodeArrayStream(
-  streamLike: StreamLike<Uint8Array | ArrayLike<number>>,
+  streamLike: ReadableStreamLike<Uint8Array | ArrayLike<number>>,
   options: DecodeAsyncOptions = defaultDecodeOptions,
 ) {
-  const stream = isReadableStream(streamLike) ? asyncIterableFromStream(streamLike) : streamLike;
+  const stream = ensureAsyncIterabe(streamLike);
 
   const decoder = new Decoder(
     options.extensionCodec,

--- a/src/decodeAsync.ts
+++ b/src/decodeAsync.ts
@@ -1,13 +1,18 @@
 import { Decoder } from "./Decoder";
 import { defaultDecodeOptions, DecodeOptions } from "./decode";
+import { isReadableStream, asyncIterableFromStream } from "./utils/stream";
 
 export type DecodeAsyncOptions = DecodeOptions;
 export const defaultDecodeAsyncOptions = defaultDecodeOptions;
 
+type StreamLike<T> = AsyncIterable<T> | ReadableStream<T>;
+
 export async function decodeAsync(
-  stream: AsyncIterable<Uint8Array | ArrayLike<number>>,
+  streamLike: StreamLike<Uint8Array | ArrayLike<number>>,
   options: DecodeAsyncOptions = defaultDecodeOptions,
 ): Promise<unknown> {
+  const stream = isReadableStream(streamLike) ? asyncIterableFromStream(streamLike) : streamLike;
+
   const decoder = new Decoder(
     options.extensionCodec,
     options.maxStrLength,
@@ -20,9 +25,11 @@ export async function decodeAsync(
 }
 
 export async function* decodeArrayStream(
-  stream: AsyncIterable<Uint8Array | ArrayLike<number>>,
+  streamLike: StreamLike<Uint8Array | ArrayLike<number>>,
   options: DecodeAsyncOptions = defaultDecodeOptions,
 ) {
+  const stream = isReadableStream(streamLike) ? asyncIterableFromStream(streamLike) : streamLike;
+
   const decoder = new Decoder(
     options.extensionCodec,
     options.maxStrLength,

--- a/src/utils/stream.ts
+++ b/src/utils/stream.ts
@@ -1,7 +1,7 @@
 // utility for whatwg streams
 
 export function isReadableStream<T>(object: unknown): object is ReadableStream<T> {
-  return typeof ReadableStream !== "object" && object instanceof ReadableStream;
+  return typeof ReadableStream !== "undefined" && object instanceof ReadableStream;
 }
 
 export async function* asyncIterableFromStream<T>(stream: ReadableStream<T>): AsyncIterable<T> {

--- a/src/utils/stream.ts
+++ b/src/utils/stream.ts
@@ -1,5 +1,7 @@
 // utility for whatwg streams
 
+export type ReadableStreamLike<T> = AsyncIterable<T> | ReadableStream<T>;
+
 export function isReadableStream<T>(object: unknown): object is ReadableStream<T> {
   return typeof ReadableStream !== "undefined" && object instanceof ReadableStream;
 }
@@ -17,5 +19,13 @@ export async function* asyncIterableFromStream<T>(stream: ReadableStream<T>): As
     }
   } finally {
     reader.releaseLock();
+  }
+}
+
+export function ensureAsyncIterabe<T>(streamLike: ReadableStreamLike<T>): AsyncIterable<T> {
+  if (isReadableStream(streamLike)) {
+    return asyncIterableFromStream(streamLike);
+  } else {
+    return streamLike;
   }
 }

--- a/src/utils/stream.ts
+++ b/src/utils/stream.ts
@@ -1,0 +1,21 @@
+// utility for whatwg streams
+
+export function isReadableStream<T>(object: unknown): object is ReadableStream<T> {
+  return typeof ReadableStream !== "object" && object instanceof ReadableStream;
+}
+
+export async function* asyncIterableFromStream<T>(stream: ReadableStream<T>): AsyncIterable<T> {
+  const reader = stream.getReader();
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        return;
+      }
+      yield value;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}

--- a/test/readme.test.ts
+++ b/test/readme.test.ts
@@ -1,8 +1,9 @@
 import { deepStrictEqual } from "assert";
-import { encode, decode } from "../src";
+import { encode, decode, decodeAsync } from "@msgpack/msgpack";
+import { asyncIterableFromStream } from "../src/utils/stream";
 
 describe("README", () => {
-  context("#synopsis", () => {
+  context("## Synopsis", () => {
     it("runs", () => {
       const object = {
         nil: null,
@@ -19,6 +20,29 @@ describe("README", () => {
       // encoded is an Uint8Array instance
 
       deepStrictEqual(decode(encoded), object);
+    });
+  });
+
+  context("## ReadableStream", () => {
+    before(function() {
+      if (typeof ReadableStream === "undefined") {
+        this.skip();
+      }
+    });
+
+    it("reads from stream", async () => {
+      const data = [1, 2, 3];
+      const encoded = encode(data);
+      const stream = new ReadableStream({
+        start(controller) {
+          for (const byte of encoded) {
+            controller.enqueue([byte]);
+          }
+          controller.close();
+        },
+      });
+
+      deepStrictEqual(await decodeAsync(asyncIterableFromStream(stream)), data);
     });
   });
 });

--- a/test/readme.test.ts
+++ b/test/readme.test.ts
@@ -1,6 +1,5 @@
 import { deepStrictEqual } from "assert";
-import { encode, decode, decodeAsync } from "@msgpack/msgpack";
-import { asyncIterableFromStream } from "../src/utils/stream";
+import { encode, decode } from "@msgpack/msgpack";
 
 describe("README", () => {
   context("## Synopsis", () => {
@@ -20,29 +19,6 @@ describe("README", () => {
       // encoded is an Uint8Array instance
 
       deepStrictEqual(decode(encoded), object);
-    });
-  });
-
-  context("## ReadableStream", () => {
-    before(function() {
-      if (typeof ReadableStream === "undefined") {
-        this.skip();
-      }
-    });
-
-    it("reads from stream", async () => {
-      const data = [1, 2, 3];
-      const encoded = encode(data);
-      const stream = new ReadableStream({
-        start(controller) {
-          for (const byte of encoded) {
-            controller.enqueue([byte]);
-          }
-          controller.close();
-        },
-      });
-
-      deepStrictEqual(await decodeAsync(asyncIterableFromStream(stream)), data);
     });
   });
 });

--- a/test/whatwg-streams.test.ts
+++ b/test/whatwg-streams.test.ts
@@ -1,6 +1,5 @@
 import { deepStrictEqual } from "assert";
 import { decodeAsync, encode, decodeArrayStream } from "@msgpack/msgpack";
-import { constants } from "http2";
 
 describe("whatwg streams", () => {
   before(function() {

--- a/test/whatwg-streams.test.ts
+++ b/test/whatwg-streams.test.ts
@@ -1,0 +1,45 @@
+import { deepStrictEqual } from "assert";
+import { decodeAsync, encode, decodeArrayStream } from "@msgpack/msgpack";
+import { constants } from "http2";
+
+describe("whatwg streams", () => {
+  before(function() {
+    if (typeof ReadableStream === "undefined") {
+      this.skip();
+    }
+  });
+
+  context("decodeAsync", async () => {
+    const data = [1, 2, 3];
+    const encoded = encode(data);
+    const stream = new ReadableStream({
+      start(controller) {
+        for (const byte of encoded) {
+          controller.enqueue([byte]);
+        }
+        controller.close();
+      },
+    });
+
+    const items = [];
+    for await (const item of decodeArrayStream(stream)) {
+      items.push(item);
+    }
+    deepStrictEqual(items, data);
+  });
+
+  it("reads from stream", async () => {
+    const data = [1, 2, 3];
+    const encoded = encode(data);
+    const stream = new ReadableStream({
+      start(controller) {
+        for (const byte of encoded) {
+          controller.enqueue([byte]);
+        }
+        controller.close();
+      },
+    });
+
+    deepStrictEqual(await decodeAsync(stream), data);
+  });
+});


### PR DESCRIPTION
whatwg-streams are standard stream api in browsers, for example as the response body of whatwg fetch api. Unfortunately, whatwg-streams do not support `AsyncIterable`, so if you want to give them to `decodeAsync()` you have to convert them to `AsyncIterable`, which is not a trivial thing.

---

This PR is working in progress, waiting for #42 is merged.