### PR TITLE
Export Decoder and Encoder for direct usage

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,9 @@ export { encode } from "./encode";
 export { decode } from "./decode";
 export { decodeAsync, decodeArrayStream } from "./decodeAsync";
 
+export { Decoder } from "./Decoder";
+export { Encoder } from "./Encoder";
+
 // Utilitiies for Extension Types:
 
 export { ExtensionCodec, ExtensionCodecType, ExtensionDecoderType, ExtensionEncoderType } from "./ExtensionCodec";


### PR DESCRIPTION
In some cases Decoder/Encoder need to be used directly without wrapper functions. For example in our project we have custom format that consist of 
binary with:

- number
- number
- array 
- number
- binary

and this structure can't be parsed or formed using regular functions, but it can be easily done by using Decoder/Encoder directly.