### PR TITLE
simplify type of decode()'s first arg; ArrayLike<number> includes Uint8Array, anyway

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,11 @@ npm install @msgpack/msgpack
 
 It encodes `data` and returns a byte array as `Uint8Array`.
 
-### `decode(buffer: ArrayLike<number> | Uint8Array, options?: DecodeOptions): unknown`
+### `decode(buffer: ArrayLike<number>, options?: DecodeOptions): unknown`
 
-It decodes `buffer` in a byte buffer and returns decoded data as `uknown`.
+It decodes `buffer` encoded as MessagePack, and returns a decoded object as `uknown`.
+
+`buffer` must be an array of bytes, which is typically `Uint8Array`.
 
 #### DecodeOptions
 
@@ -63,19 +65,19 @@ maxExtLength | number | `4_294_967_295` (UINT32_MAX)
 
 You can use `max${Type}Length` to limit the length of each type decoded.
 
-### `decodeAsync(stream: AsyncIterable<Uint8Array | ArrayLike<number>> | ReadableStream<Uint8Array | ArrayLike<number>>, options?: DecodeAsyncOptions): Promise<unknown>`
+### `decodeAsync(stream: AsyncIterable<ArrayLike<number>> | ReadableStream<ArrayLike<number>>, options?: DecodeAsyncOptions): Promise<unknown>`
 
 It decodes `stream` in an async iterable of byte arrays and returns decoded data as `uknown` wrapped in `Promise`. This function works asyncronously.
 
 Note that `decodeAsync()` acceps the same options as `decode()`.
 
-### `decodeArrayStream(stream: AsyncIterable<Uint8Array | ArrayLike<number>> | ReadableStream<Uint8Array | ArrayLike<number>>, options?: DecodeAsyncOptions): AsyncIterable<unknown>`
+### `decodeArrayStream(stream: AsyncIterable< ArrayLike<number>> | ReadableStream<ArrayLike<number>>, options?: DecodeAsyncOptions): AsyncIterable<unknown>`
 
 It is alike to `decodeAsync()`, but only accepts an array of items as the input `stream`, and emits the decoded item one by one.
 
 It throws errors when the input is not an array.
 
-### `decodeStream(stream: AsyncIterable<Uint8Array | ArrayLike<number>> | ReadableStream<Uint8Array | ArrayLike<number>>, options?: DecodeAsyncOptions): AsyncIterable<unknown>`
+### `decodeStream(stream: AsyncIterable<ArrayLike<number>> | ReadableStream<ArrayLike<number>>, options?: DecodeAsyncOptions): AsyncIterable<unknown>`
 
 It is like to `decodeAsync()` and `decodeArrayStream()`, but the input `stream` consists of independent MessagePack items.
 

--- a/src/Decoder.ts
+++ b/src/Decoder.ts
@@ -68,13 +68,13 @@ export class Decoder {
     readonly maxExtLength = DEFAULT_MAX_LENGTH,
   ) {}
 
-  setBuffer(buffer: ArrayLike<number> | Uint8Array): void {
+  setBuffer(buffer: ArrayLike<number>): void {
     this.bytes = ensureUint8Array(buffer);
     this.view = createDataView(this.bytes);
     this.pos = 0;
   }
 
-  appendBuffer(buffer: Uint8Array | ArrayLike<number>) {
+  appendBuffer(buffer: ArrayLike<number>) {
     if (this.headByte === HEAD_BYTE_REQUIRED && !this.hasRemaining()) {
       this.setBuffer(buffer);
     } else {
@@ -105,7 +105,7 @@ export class Decoder {
     return object;
   }
 
-  async decodeOneAsync(stream: AsyncIterable<ArrayLike<number> | Uint8Array>): Promise<unknown> {
+  async decodeOneAsync(stream: AsyncIterable<ArrayLike<number>>): Promise<unknown> {
     let decoded = false;
     let object: unknown;
     for await (const buffer of stream) {
@@ -140,7 +140,7 @@ export class Decoder {
     );
   }
 
-  async *decodeStream(stream: AsyncIterable<ArrayLike<number> | Uint8Array>) {
+  async *decodeStream(stream: AsyncIterable<ArrayLike<number>>) {
     for await (const buffer of stream) {
       this.appendBuffer(buffer);
 
@@ -159,7 +159,7 @@ export class Decoder {
     }
   }
 
-  async *decodeArrayStream(stream: AsyncIterable<ArrayLike<number> | Uint8Array>) {
+  async *decodeArrayStream(stream: AsyncIterable<ArrayLike<number>>) {
     let headerParsed = false;
     let decoded = false;
     let itemsLeft = 0;

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -35,10 +35,7 @@ export type DecodeOptions = Partial<
 
 export const defaultDecodeOptions: DecodeOptions = {};
 
-export function decode(
-  buffer: ReadonlyArray<number> | Uint8Array,
-  options: DecodeOptions = defaultDecodeOptions,
-): unknown {
+export function decode(buffer: ArrayLike<number>, options: DecodeOptions = defaultDecodeOptions): unknown {
   const decoder = new Decoder(
     options.extensionCodec,
     options.maxStrLength,

--- a/src/decodeAsync.ts
+++ b/src/decodeAsync.ts
@@ -6,7 +6,7 @@ export type DecodeAsyncOptions = DecodeOptions;
 export const defaultDecodeAsyncOptions = defaultDecodeOptions;
 
 export async function decodeAsync(
-  streamLike: ReadableStreamLike<Uint8Array | ArrayLike<number>>,
+  streamLike: ReadableStreamLike<ArrayLike<number>>,
   options: DecodeAsyncOptions = defaultDecodeOptions,
 ): Promise<unknown> {
   const stream = ensureAsyncIterabe(streamLike);
@@ -23,7 +23,7 @@ export async function decodeAsync(
 }
 
 export function decodeArrayStream(
-  streamLike: ReadableStreamLike<Uint8Array | ArrayLike<number>>,
+  streamLike: ReadableStreamLike<ArrayLike<number>>,
   options: DecodeAsyncOptions = defaultDecodeOptions,
 ) {
   const stream = ensureAsyncIterabe(streamLike);
@@ -41,7 +41,7 @@ export function decodeArrayStream(
 }
 
 export function decodeStream(
-  streamLike: ReadableStreamLike<Uint8Array | ArrayLike<number>>,
+  streamLike: ReadableStreamLike<ArrayLike<number>>,
   options: DecodeAsyncOptions = defaultDecodeOptions,
 ) {
   const stream = ensureAsyncIterabe(streamLike);


### PR DESCRIPTION
In readme, `decodeStream(stream: AsyncIterable<Uint8Array | ArrayLike<number>> | ReadableStream<Uint8Array | ArrayLike<number>>, options?: DecodeAsyncOptions): AsyncIterable<unknown>` is too complex to read.

Because `Uint8Array` includes `ArrayLike<number>`, `Uint8Array | ArrayLike<number>` can be simplified  to `ArrayLike<number>`.