### PR TITLE
add JavaScriptCodec to serialize JavaScript data structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:cover:wasm": "npx nyc --no-clean npm run test:wasm",
     "test:cover:td": "npx nyc --no-clean npm run test:td",
     "cover:clean": "rimraf .nyc_output coverage/",
-    "cover:report": "nyc report --reporter=text-summary --reporter=html --reporter=json",
+    "cover:report": "npx nyc report --reporter=text-summary --reporter=html --reporter=json",
     "test:browser": "karma start --single-run",
     "test:browser:firefox": "karma start --single-run --browsers FirefoxHeadless",
     "test:browser:chrome": "karma start --single-run --browsers ChromeHeadless",

--- a/src/ExtensionCodec.ts
+++ b/src/ExtensionCodec.ts
@@ -50,18 +50,6 @@ export class ExtensionCodec implements ExtensionCodecType {
   }
 
   public tryToEncode(object: unknown): ExtData | null {
-    // built-in extensions
-    for (let i = 0; i < this.builtInEncoders.length; i++) {
-      const encoder = this.builtInEncoders[i];
-      if (encoder != null) {
-        const data = encoder(object);
-        if (data != null) {
-          const type = -1 - i;
-          return new ExtData(type, data);
-        }
-      }
-    }
-
     // custom extensions
     for (let i = 0; i < this.encoders.length; i++) {
       const encoder = this.encoders[i];
@@ -69,6 +57,18 @@ export class ExtensionCodec implements ExtensionCodecType {
         const data = encoder(object);
         if (data != null) {
           const type = i;
+          return new ExtData(type, data);
+        }
+      }
+    }
+
+    // built-in extensions
+    for (let i = 0; i < this.builtInEncoders.length; i++) {
+      const encoder = this.builtInEncoders[i];
+      if (encoder != null) {
+        const data = encoder(object);
+        if (data != null) {
+          const type = -1 - i;
           return new ExtData(type, data);
         }
       }

--- a/src/JavaScriptCodec.ts
+++ b/src/JavaScriptCodec.ts
@@ -9,6 +9,7 @@ const enum JSData {
   Set,
   Date,
   RegExp,
+  BigInt,
 }
 
 export function encodeJavaScriptData(input: unknown): Uint8Array | null {
@@ -22,6 +23,8 @@ export function encodeJavaScriptData(input: unknown): Uint8Array | null {
     return encode([JSData.Date, input.getTime()]);
   } else if (input instanceof RegExp) {
     return encode([JSData.RegExp, [input.source, input.flags]]);
+  } else if (typeof input === "bigint") {
+    return encode([JSData.BigInt, input.toString()]);
   } else {
     return null;
   }
@@ -43,6 +46,9 @@ export function decodeJavaScriptData(data: Uint8Array) {
     case JSData.RegExp: {
       const [pattern, flags] = source;
       return new RegExp(pattern, flags);
+    }
+    case JSData.BigInt: {
+      return BigInt(source);
     }
     default: {
       throw new Error(`Unknown data type: ${jsDataType}`);

--- a/src/JavaScriptCodec.ts
+++ b/src/JavaScriptCodec.ts
@@ -2,7 +2,7 @@ import { ExtensionCodec, ExtensionCodecType } from "./ExtensionCodec";
 import { encode } from "./encode";
 import { decode } from "./decode";
 
-export const JavaScriptCodecType = 0;
+export const EXT_JAVASCRIPT = 0;
 
 const enum JSData {
   Map,
@@ -60,7 +60,7 @@ export const JavaScriptCodec: ExtensionCodecType = (() => {
   const ext = new ExtensionCodec();
 
   ext.register({
-    type: JavaScriptCodecType,
+    type: EXT_JAVASCRIPT,
     encode: encodeJavaScriptData,
     decode: decodeJavaScriptData,
   });

--- a/src/JavaScriptCodec.ts
+++ b/src/JavaScriptCodec.ts
@@ -1,0 +1,59 @@
+import { ExtensionCodec, ExtensionCodecType } from "./ExtensionCodec";
+import { encode } from "./encode";
+import { decode } from "./decode";
+
+export const JavaScriptCodecType = 0;
+
+export function encodeJavaScriptData(input: unknown): Uint8Array | null {
+  if (input instanceof Map) {
+    return encode(["Map", [...input]]);
+  } else if (input instanceof Set) {
+    return encode(["Set", [...input]]);
+  } else if (input instanceof Date) {
+    // Not a MessagePack timestamp because
+    // it may be overrided by users
+    return encode(["Date", input.getTime()]);
+  } else if (input instanceof RegExp) {
+    return encode(["RegExp", [input.source, input.flags]]);
+  } else {
+    return null;
+  }
+}
+
+export function decodeJavaScriptData(data: Uint8Array) {
+  const [constructor, source] = decode(data) as [string, any];
+
+  switch (constructor) {
+    case "undefined": {
+      return undefined;
+    }
+    case "Map": {
+      return new Map<unknown, unknown>(source);
+    }
+    case "Set": {
+      return new Set<unknown>(source);
+    }
+    case "Date": {
+      return new Date(source);
+    }
+    case "RegExp": {
+      const [pattern, flags] = source;
+      return new RegExp(pattern, flags);
+    }
+    default: {
+      throw new Error(`Unknown constructor: ${constructor}`);
+    }
+  }
+}
+
+export const JavaScriptCodec: ExtensionCodecType = (() => {
+  const ext = new ExtensionCodec();
+
+  ext.register({
+    type: JavaScriptCodecType,
+    encode: encodeJavaScriptData,
+    decode: decodeJavaScriptData,
+  });
+
+  return ext;
+})();

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,4 +20,6 @@ export {
   decodeTimestampExtension,
 } from "./timestamp";
 
+export { JavaScriptCodec, JavaScriptCodecType, encodeJavaScriptData, decodeJavaScriptData } from "./JavaScriptCodec";
+
 export { WASM_AVAILABLE as __WASM_AVAILABLE } from "./wasmFunctions";

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,6 @@ export {
   decodeTimestampExtension,
 } from "./timestamp";
 
-export { JavaScriptCodec, JavaScriptCodecType, encodeJavaScriptData, decodeJavaScriptData } from "./JavaScriptCodec";
+export { JavaScriptCodec, EXT_JAVASCRIPT, encodeJavaScriptData, decodeJavaScriptData } from "./JavaScriptCodec";
 
 export { WASM_AVAILABLE as __WASM_AVAILABLE } from "./wasmFunctions";

--- a/test/javascript-codec.test.ts
+++ b/test/javascript-codec.test.ts
@@ -1,0 +1,28 @@
+import assert from "assert";
+import { encode, decode } from "@msgpack/msgpack";
+import { JavaScriptCodec } from "src/JavaScriptCodec";
+
+describe("JavaScriptCodec", () => {
+  context("mixed", () => {
+    // this data comes from https://github.com/yahoo/serialize-javascript
+
+    it("encodes and decodes the object", () => {
+      const object = {
+        str: "string",
+        num: 0,
+        obj: { foo: "foo", bar: "bar" },
+        arr: [1, 2, 3],
+        bool: true,
+        nil: null,
+        // undef: undefined,
+        date: new Date("Thu, 28 Apr 2016 22:02:17 GMT"),
+        map: new Map([["foo", 10], ["bar", 20]]),
+        set: new Set([123, 456]),
+        regexp: /foo\n/i,
+      };
+      const encoded = encode(object, { extensionCodec: JavaScriptCodec });
+
+      assert.deepStrictEqual(decode(encoded, { extensionCodec: JavaScriptCodec }), object);
+    });
+  });
+});

--- a/test/javascript-codec.test.ts
+++ b/test/javascript-codec.test.ts
@@ -14,11 +14,12 @@ describe("JavaScriptCodec", () => {
         arr: [1, 2, 3],
         bool: true,
         nil: null,
-        // undef: undefined,
+        // undef: undefined, // not supported
         date: new Date("Thu, 28 Apr 2016 22:02:17 GMT"),
         map: new Map([["foo", 10], ["bar", 20]]),
         set: new Set([123, 456]),
         regexp: /foo\n/i,
+        bigint: typeof(BigInt) !== "undefined" ? BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1) : null,
       };
       const encoded = encode(object, { extensionCodec: JavaScriptCodec });
 

--- a/test/javascript-codec.test.ts
+++ b/test/javascript-codec.test.ts
@@ -1,6 +1,5 @@
 import assert from "assert";
-import { encode, decode } from "@msgpack/msgpack";
-import { JavaScriptCodec } from "src/JavaScriptCodec";
+import { encode, decode, JavaScriptCodec } from "@msgpack/msgpack";
 
 describe("JavaScriptCodec", () => {
   context("mixed", () => {


### PR DESCRIPTION
This is an experimental feature to serialize and deserialize JavaScript data structure, just like as https://github.com/yahoo/serialize-javascript

<del>I'm investigating that it really improves performance when `serialize-javascript` is replaced to msgpack, so it is marked as DO NOT MERGE for now.</del>

It's time to merge. Although some msgpack implementation in JavaScript has the default extensions for basic JavaScript data types like this PR, `@msgpack/msgpack` doesn't provide them by default because its purpose is to exchange data with other systems sometimes implemented in other languages.

Resolve #58 

## See also

* https://github.com/kawanet/msgpack-lite
* https://github.com/mcollina/msgpack5

