### PR TITLE
experimental string cache in encoder but it's slow

### DIFF
--- a/benchmark/string.ts
+++ b/benchmark/string.ts
@@ -4,8 +4,8 @@ import { WASM_AVAILABLE } from "../src/wasmFunctions";
 
 console.log(`WASM_AVAILABLE=${WASM_AVAILABLE}`);
 
-const ascii = "A".repeat(40000);
-const emoji = "🌏".repeat(20000);
+const ascii = "A".repeat(30);
+const emoji = "🌏".repeat(8);
 
 {
   // warm up ascii
@@ -17,13 +17,13 @@ const emoji = "🌏".repeat(20000);
   // run
 
   console.time("encode ascii");
-  for (let i = 0; i < 1000; i++) {
+  for (let i = 0; i < 1000000; i++) {
     encode(data);
   }
   console.timeEnd("encode ascii");
 
   console.time("decode ascii");
-  for (let i = 0; i < 1000; i++) {
+  for (let i = 0; i < 1000000; i++) {
     decode(encoded);
   }
   console.timeEnd("decode ascii");
@@ -40,13 +40,13 @@ const emoji = "🌏".repeat(20000);
   // run
 
   console.time("encode emoji");
-  for (let i = 0; i < 1000; i++) {
+  for (let i = 0; i < 1000000; i++) {
     encode(data);
   }
   console.timeEnd("encode emoji");
 
   console.time("decode emoji");
-  for (let i = 0; i < 1000; i++) {
+  for (let i = 0; i < 1000000; i++) {
     decode(encoded);
   }
   console.timeEnd("decode emoji");


### PR DESCRIPTION
This is an Encoder version of https://github.com/msgpack/msgpack-javascript/pull/54 but it makes encode() to be slower.

no cache:

```
$ npx ts-node benchmark/string.ts

encode ascii: 1624.344ms
decode ascii: 505.599ms
encode / decode emoji data.length=16 encoded.byteLength=34
encode emoji: 1569.745ms
decode emoji: 368.443ms
```

with cache:

```
$ npx ts-node benchmark/string.ts
encode / decode ascii data.length=30 encoded.byteLength=31
encode ascii: 2075.262ms
decode ascii: 473.800ms
encode / decode emoji data.length=16 encoded.byteLength=34
encode emoji: 1648.992ms
decode emoji: 376.590ms
```

cc: @sergeyzenchenko 