### PR TITLE
Support canonical encoding by adding sortKeys option to encode()

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ npm install @msgpack/msgpack
 
 It encodes `data` and returns a byte array as `Uint8Array`.
 
+#### EncodeOptions
+
+Name|Type|Default
+----|----|----
+extensionCodec | ExtensionCodec | `ExtensinCodec.defaultCodec`
+maxDepth | number | `100`
+initialBufferSize | number | `2048`
+sortKeys | boolean | false
+
 ### `decode(buffer: ArrayLike<number>, options?: DecodeOptions): unknown`
 
 It decodes `buffer` encoded as MessagePack, and returns a decoded object as `uknown`.

--- a/src/Encoder.ts
+++ b/src/Encoder.ts
@@ -224,16 +224,6 @@ export class Encoder {
     }
   }
 
-  countObjectKeys(object: Record<string, unknown>): number {
-    let count = 0;
-    for (const key in object) {
-      if (Object.prototype.hasOwnProperty.call(object, key)) {
-        count++;
-      }
-    }
-    return count;
-  }
-
   encodeMap(object: Record<string, unknown>, depth: number) {
     const keys = Object.keys(object);
     if (this.sortKeys) {

--- a/src/Encoder.ts
+++ b/src/Encoder.ts
@@ -17,6 +17,7 @@ export class Encoder {
     readonly extensionCodec = ExtensionCodec.defaultCodec,
     readonly maxDepth = DEFAULT_MAX_DEPTH,
     readonly initialBufferSize = DEFAULT_INITIAL_BUFFER_SIZE,
+    readonly sortKeys = false,
   ) {}
 
   encode(object: unknown, depth: number): void {
@@ -234,7 +235,11 @@ export class Encoder {
   }
 
   encodeMap(object: Record<string, unknown>, depth: number) {
-    const size = this.countObjectKeys(object);
+    const keys = Object.keys(object);
+    if (this.sortKeys) {
+      keys.sort();
+    }
+    const size = keys.length;
     if (size < 16) {
       // fixmap
       this.writeU8(0x80 + size);
@@ -249,11 +254,11 @@ export class Encoder {
     } else {
       throw new Error(`Too large map object: ${size}`);
     }
-    for (const key in object) {
-      if (Object.prototype.hasOwnProperty.call(object, key)) {
-        this.encodeString(key);
-        this.encode(object[key], depth + 1);
-      }
+
+    for (let i = 0; i < size; i++) {
+      const key = keys[i];
+      this.encodeString(key);
+      this.encode(object[key], depth + 1);
     }
   }
 

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -6,13 +6,14 @@ export type EncodeOptions = Partial<
     extensionCodec: ExtensionCodecType;
     maxDepth: number;
     initialBufferSize: number;
+    sortKeys: boolean;
   }>
 >;
 
 const defaultEncodeOptions = {};
 
 export function encode(value: unknown, options: EncodeOptions = defaultEncodeOptions): Uint8Array {
-  const encoder = new Encoder(options.extensionCodec, options.maxDepth, options.initialBufferSize);
+  const encoder = new Encoder(options.extensionCodec, options.maxDepth, options.initialBufferSize, options.sortKeys);
   encoder.encode(value, 1);
   return encoder.getUint8Array();
 }

--- a/test/encode-options.test.ts
+++ b/test/encode-options.test.ts
@@ -1,0 +1,13 @@
+import assert from "assert";
+import { encode } from "@msgpack/msgpack";
+
+describe("encode options", () => {
+  context("sortKeys", () => {
+    it("canonicalize encoded binaries", () => {
+      assert.deepStrictEqual(
+        encode({ a: 1, b: 2 }, { sortKeys: true }),
+        encode({ b: 2, a: 1 }, { sortKeys: true }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
* https://github.com/mcollina/msgpack5 has the same option `sortKeys`
* msgpack-lite has pull request https://github.com/kawanet/msgpack-lite/pull/103 has a pull-request for canonical encoding