### PR TITLE
allow stream ponyfill as ReadableStream

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6735,6 +6735,12 @@
         "neo-async": "^2.5.0"
       }
     },
+    "web-streams-polyfill": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-2.0.3.tgz",
+      "integrity": "sha512-pOqiHmL3RBAGS+SgOR42RbPU6nc8/n15N2rsOXFYHLnTfs2Z8QHs8AizOeOaYEnhwPN4+hu3M2D9XvAqzvt6MA==",
+      "dev": true
+    },
     "webpack": {
       "version": "4.33.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.33.0.tgz",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "ts-node": "^8.2.0",
     "tsconfig-paths": "^3.8.0",
     "typescript": "^3.5.1",
+    "web-streams-polyfill": "^2.0.3",
     "webpack": "^4.30.0",
     "webpack-cli": "^3.3.1"
   },

--- a/src/utils/stream.ts
+++ b/src/utils/stream.ts
@@ -1,9 +1,13 @@
 // utility for whatwg streams
 
+// The living standard of whatwg streams says
+// ReadableStream is also AsyncIterable, but
+// as of June 2019, no browser implements it.
+// See https://streams.spec.whatwg.org/ for details
 export type ReadableStreamLike<T> = AsyncIterable<T> | ReadableStream<T>;
 
-export function isReadableStream<T>(object: unknown): object is ReadableStream<T> {
-  return typeof ReadableStream !== "undefined" && object instanceof ReadableStream;
+export function isAsyncIterable<T>(object: object): object is AsyncIterable<T> {
+  return (object as any)[Symbol.asyncIterator] != null;
 }
 
 export async function* asyncIterableFromStream<T>(stream: ReadableStream<T>): AsyncIterable<T> {
@@ -23,9 +27,9 @@ export async function* asyncIterableFromStream<T>(stream: ReadableStream<T>): As
 }
 
 export function ensureAsyncIterabe<T>(streamLike: ReadableStreamLike<T>): AsyncIterable<T> {
-  if (isReadableStream(streamLike)) {
-    return asyncIterableFromStream(streamLike);
-  } else {
+  if (isAsyncIterable(streamLike)) {
     return streamLike;
+  } else {
+    return asyncIterableFromStream(streamLike);
   }
 }


### PR DESCRIPTION
`object instanceof ReadableStream` does not allow ponyfills, a clone of built-in class, so it takes other ways.

In addition, this PR also supports a newer feature`ReadableStream.prototype[@@asyncIterator]`, which is supported by no browser as of June 2019.