### PR TITLE
fix AMD-style modules; add amd-example.html for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ deepStrictEqual(decode(encoded), object);
   - [NodeJS](#nodejs)
 - [Benchmark](#benchmark)
 - [Distribution](#distribution)
+  - [NPM / npmjs.com](#npm--npmjscom)
+  - [CDN / unpkg.com](#cdn--unpkgcom)
 - [Maintenance](#maintenance)
   - [Testing](#testing)
   - [Continuous Integration](#continuous-integration)
@@ -388,6 +390,8 @@ Note that `Buffer.from()` for `JSON.stringify()` is added to emulate I/O where a
 
 ## Distribution
 
+### NPM / npmjs.com
+
 The NPM package distributed in npmjs.com includes both ES2015+ and ES5 files:
 
 * `dist/` is compiled into ES2015+
@@ -396,6 +400,16 @@ The NPM package distributed in npmjs.com includes both ES2015+ and ES5 files:
   * `dist.es5/webpack.js` - an optional, non-minified file (UMD)
 
 If you use NodeJS and/or webpack, their module resolvers use the suitable one automatically.
+
+### CDN / unpkg.com
+
+This library is availble via CDN:
+
+```html
+<script crossorigin src="https://unpkg.com/@msgpack/msgpack"></script>
+```
+
+It loads `MessagePack` module to the global object.
 
 ## Maintenance
 

--- a/example/amd-example.html
+++ b/example/amd-example.html
@@ -1,10 +1,7 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <script src="../dist.es5/msgpack.min.js"></script>
-    <script>
-      console.log(MessagePack);
-    </script>
     <style>
       main {
         width: 80%;
@@ -15,9 +12,7 @@
   <body>
     <main>
       <h1>AMD for @msgpack/msgpack</h1>
-      <pre><code>&lt;script src="https://unpkg.com/@msgpack/msgpack"&gt;&lt;/script&gt;
-          </code></pre>
-
+      <pre><code>&lt;script src="https://unpkg.com/@msgpack/msgpack"&gt;&lt;/script&gt;</code></pre>
       <script src="./amd-example.js"></script>
     </main>
   </body>

--- a/example/amd-example.html
+++ b/example/amd-example.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="../dist.es5/msgpack.min.js"></script>
+    <script>
+      console.log(MessagePack);
+    </script>
+    <style>
+      main {
+        width: 80%;
+        margin: 20px auto;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>AMD for @msgpack/msgpack</h1>
+      <pre><code>&lt;script src="https://unpkg.com/@msgpack/msgpack"&gt;&lt;/script&gt;
+          </code></pre>
+
+      <script src="./amd-example.js"></script>
+    </main>
+  </body>
+</html>

--- a/example/amd-example.js
+++ b/example/amd-example.js
@@ -1,0 +1,26 @@
+/* eslint-disable no-console */
+"use strict";
+
+try {
+  const object = {
+    nil: null,
+    integer: 1,
+    float: Math.PI,
+    string: "Hello, world!",
+    binary: Uint8Array.from([1, 2, 3]),
+    array: [10, 20, 30],
+    map: { foo: "bar" },
+    timestampExt: new Date(),
+  };
+
+  document.writeln("<p>input:</p>");
+  document.writeln(`<pre><code>${JSON.stringify(object, undefined, 2)}</code></pre>`);
+
+  const encoded = MessagePack.encode(object);
+
+  document.writeln("<p>output:</p>");
+  document.writeln(`<pre><code>${JSON.stringify(MessagePack.decode(encoded), undefined, 2)}</code></pre>`);
+} catch (e) {
+  console.error(e);
+  document.write(`<p style="color: red">${e.constructor.name}: ${e.message}</p>`);
+}

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -12,6 +12,7 @@ const config = {
   entry: "./src/index.ts",
   output: {
     path: path.resolve(__dirname, "dist.es5"),
+    library: "MessagePack",
     libraryTarget: "umd",
     globalObject: "this",
   },
@@ -37,6 +38,7 @@ const config = {
     new webpack.DefinePlugin({
       "process.env.WASM": JSON.stringify(null), // use only MSGPACK_WASM
       "process.env.TEXT_ENCODING": JSON.stringify("null"),
+      "process.env.TEXT_DECODER": JSON.stringify(null),
     }),
   ],
   externals: {


### PR DESCRIPTION
* use the name `MessagePack` for AMD
* Remove all the nodejs `process` global objects
 

Now `<script src="https://unpkg.com/@msgpack/msgpack"></script>` loads `MessagePack` as its module.