### PR TITLE
fix int8 range in encoding

### DIFF
--- a/src/Encoder.ts
+++ b/src/Encoder.ts
@@ -99,7 +99,7 @@ export class Encoder {
         if (object >= -0x20) {
           // nagative fixint
           this.writeU8(0xe0 | (object + 0x20));
-        } else if (object > -0x80) {
+        } else if (object >= -0x80) {
           // int 8
           this.writeU8(0xd0);
           this.writeI8(object);

--- a/test/msgpack-test-suite.test.ts
+++ b/test/msgpack-test-suite.test.ts
@@ -120,4 +120,10 @@ describe("msgpack-test-suite", () => {
       });
     }
   });
+
+  describe("encoding in minimum values", () => {
+    it("int 8", () => {
+      assert.deepStrictEqual(encode(-128), Uint8Array.from([0xd0, 0x80]));
+    });
+  });
 });


### PR DESCRIPTION
pointed out by https://github.com/msgpack/website/pull/19

This is a long existing bug coming from the classic version of msgpack-javascript
