### PR TITLE
if you exceed CHUNK_SIZE safari will crash with a range error

### DIFF
--- a/src/utils/utf8.ts
+++ b/src/utils/utf8.ts
@@ -138,7 +138,7 @@ export function utf8DecodeJs(bytes: Uint8Array, inputOffset: number, byteLength:
       units.push(byte1);
     }
 
-    if (units.length - 4 >= CHUNK_SIZE) {
+    if (units.length >= CHUNK_SIZE) {
       result += String.fromCharCode(...units);
       units.length = 0;
     }


### PR DESCRIPTION
Hi,
I noticed when I passed very long strings to decode it would crash out with `RangeError: Maximum call stack size exceeded.`. The code seemingly already protects against this with `CHUNK_SIZE` but allows it to go over by 4 items due to the `- 4` (unclear why this exists). Removing the `-4` stops this crash.