### PR TITLE
protect stack size even further

### DIFF
--- a/src/utils/utf8.ts
+++ b/src/utils/utf8.ts
@@ -100,7 +100,7 @@ function utf8EncodeTEencodeInto(str: string, output: Uint8Array, outputOffset: n
 export const utf8EncodeTE =
   sharedTextEncoder && sharedTextEncoder.encodeInto ? utf8EncodeTEencodeInto : utf8EncodeTEencode;
 
-const CHUNK_SIZE = 0x10_000;
+const CHUNK_SIZE = 0x1_000;
 
 export function utf8DecodeJs(bytes: Uint8Array, inputOffset: number, byteLength: number): string {
   let offset = inputOffset;


### PR DESCRIPTION
Hi,

Sorry to touch this same area again! Turns out my previous fix wasn't enough for most use cases. In isolation reducing it by `4` was enough to pass tests but if your code is running on any kind of stack itself you'll run out of stack space. Looking at what some other projects do it seems pretty popular to just change this value to give yourself some headroom (like: https://github.com/feross/buffer/blob/master/index.js#L1023)
