### PR TITLE
Migration to .mocharc.js from mocha.opts

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,0 +1,11 @@
+'use strict';
+
+require("ts-node/register");
+require("tsconfig-paths/register");
+
+module.exports = {
+  diff: true,
+  extension: ['ts'],
+  package: '../package.json',
+  timeout: 10_000,
+};

--- a/.mocharc.js
+++ b/.mocharc.js
@@ -7,5 +7,5 @@ module.exports = {
   diff: true,
   extension: ['ts'],
   package: '../package.json',
-  timeout: 10_000,
+  timeout: 10000,
 };

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,0 @@
---require ts-node/register
---require tsconfig-paths/register
---timeout 10000


### PR DESCRIPTION
Because `mocha.opts` is deprecated in Mocha 7.

https://mochajs.org/#configuring-mocha-nodejs