### PR TITLE
Fix import typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ It throws errors when the input is not an array-family.
 for example:
 
 ```typescript
-import { encode } from "@msgpack/msgpack";
+import { decodeArrayStream } from "@msgpack/msgpack";
 
 const stream: AsyncIterator<Uint8Array>;
 
@@ -202,7 +202,7 @@ In other words, it decodes an unlimited stream and emits an item one by one.
 for example:
 
 ```typescript
-import { encode } from "@msgpack/msgpack";
+import { decodeStream } from "@msgpack/msgpack";
 
 const stream: AsyncIterator<Uint8Array>;
 


### PR DESCRIPTION
Looks like there is a typo in the examples for `decodeArrayStream` and `decodeStream`, they both import `encode`.