### PR TITLE
make Encoder/Decoder instances easily reusable

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,7 +45,7 @@ module.exports = {
     "@typescript-eslint/no-throw-literal": "warn",
     "@typescript-eslint/no-extra-semi": "warn",
     "@typescript-eslint/no-extra-non-null-assertion": "warn",
-    "@typescript-eslint/no-unused-vars": "warn",
+    "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }],
     "@typescript-eslint/no-use-before-define": "warn",
     "@typescript-eslint/no-for-in-array": "warn",
     "@typescript-eslint/no-unnecessary-condition": ["warn", { "allowConstantLoopConditions": true }],

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ deepStrictEqual(decode(encoded), object);
   - [`decodeArrayStream(stream: AsyncIterable<ArrayLike<number>> | ReadableStream<ArrayLike<number>>, options?: DecodeAsyncOptions): AsyncIterable<unknown>`](#decodearraystreamstream-asynciterablearraylikenumber--readablestreamarraylikenumber-options-decodeasyncoptions-asynciterableunknown)
   - [`decodeStream(stream: AsyncIterable<ArrayLike<number>> | ReadableStream<ArrayLike<number>>, options?: DecodeAsyncOptions): AsyncIterable<unknown>`](#decodestreamstream-asynciterablearraylikenumber--readablestreamarraylikenumber-options-decodeasyncoptions-asynciterableunknown)
   - [Extension Types](#extension-types)
-    - [Codec context](#codec-context)
+    - [ExtensionCodec context](#extensioncodec-context)
     - [Handling BigInt with ExtensionCodec](#handling-bigint-with-extensioncodec)
     - [The temporal module as timestamp extensions](#the-temporal-module-as-timestamp-extensions)
 - [Decoding a Blob](#decoding-a-blob)
@@ -266,7 +266,7 @@ const decoded = decode(encoded, { extensionCodec });
 
 Not that extension types for custom objects must be `[0, 127]`, while `[-1, -128]` is reserved for MessagePack itself.
 
-#### Codec context
+#### ExtensionCodec context
 
 When using an extension codec, it may be necessary to keep encoding/decoding state, to keep track of which objects got encoded/re-created. To do this, pass a `context` to the `EncodeOptions` and `DecodeOptions` (and if using typescript, type the `ExtensionCodec` too). Don't forget to pass the `{extensionCodec, context}` along recursive encoding/decoding:
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ deepStrictEqual(decode(encoded), object);
   - [`decodeAsync(stream: AsyncIterable<ArrayLike<number>> | ReadableStream<ArrayLike<number>>, options?: DecodeAsyncOptions): Promise<unknown>`](#decodeasyncstream-asynciterablearraylikenumber--readablestreamarraylikenumber-options-decodeasyncoptions-promiseunknown)
   - [`decodeArrayStream(stream: AsyncIterable<ArrayLike<number>> | ReadableStream<ArrayLike<number>>, options?: DecodeAsyncOptions): AsyncIterable<unknown>`](#decodearraystreamstream-asynciterablearraylikenumber--readablestreamarraylikenumber-options-decodeasyncoptions-asynciterableunknown)
   - [`decodeStream(stream: AsyncIterable<ArrayLike<number>> | ReadableStream<ArrayLike<number>>, options?: DecodeAsyncOptions): AsyncIterable<unknown>`](#decodestreamstream-asynciterablearraylikenumber--readablestreamarraylikenumber-options-decodeasyncoptions-asynciterableunknown)
-  - [Extension Types](#extension-types)
+  - [Reusing Encoder and Decoder instances](#reusing-encoder-and-decoder-instances)
+- [Extension Types](#extension-types)
     - [ExtensionCodec context](#extensioncodec-context)
     - [Handling BigInt with ExtensionCodec](#handling-bigint-with-extensioncodec)
     - [The temporal module as timestamp extensions](#the-temporal-module-as-timestamp-extensions)
@@ -212,7 +213,27 @@ for await (const item of decodeStream(stream)) {
 }
 ```
 
-### Extension Types
+### Reusing Encoder and Decoder instances
+
+`Encoder` and `Decoder` classes is provided for better performance:
+
+```typescript
+import { deepStrictEqual } from "assert";
+import { Encoder, Decoder } from "@msgpack/msgpack";
+
+const encoder = new Encoder();
+const decoder = new Decoder();
+
+const encoded: Uint8Array = encoder.encode(object);
+deepStrictEqual(decoder.decode(encoded), object);
+```
+
+According to our benchmark, reusing `Encoder` instance is about 2% faster
+than `encode()` function, and reusing `Decoder` instance is about 35% faster
+than `decode()` function. Note that the result should vary in environments
+and data structure.
+
+## Extension Types
 
 To handle [MessagePack Extension Types](https://github.com/msgpack/msgpack/blob/master/spec.md#extension-types), this library provides `ExtensionCodec` class.
 

--- a/benchmark/benchmark-from-msgpack-lite.ts
+++ b/benchmark/benchmark-from-msgpack-lite.ts
@@ -67,7 +67,7 @@ if (msgpack_msgpack) {
   const encoder = new msgpack_msgpack.Encoder();
   const decoder = new msgpack_msgpack.Decoder();
   buf = bench('buf = /* @msgpack/msgpack */ encoder.encode(obj);', (data) => encoder.encode(data), data);
-  obj = bench('obj = /* @msgpack/msgpack */ decoder.decodeSync(buf);', (buf) => decoder.decodeSync(buf), buf);
+  obj = bench('obj = /* @msgpack/msgpack */ decoder.decode(buf);', (buf) => decoder.decode(buf), buf);
   runTest(obj);
 
   if (process.env.CACHE_HIT_RATE) {

--- a/benchmark/benchmark-from-msgpack-lite.ts
+++ b/benchmark/benchmark-from-msgpack-lite.ts
@@ -69,6 +69,11 @@ if (msgpack_msgpack) {
   buf = bench('buf = /* @msgpack/msgpack */ encoder.encode(obj);', (data) => encoder.encode(data), data);
   obj = bench('obj = /* @msgpack/msgpack */ decoder.decodeSync(buf);', (buf) => decoder.decodeSync(buf), buf);
   runTest(obj);
+
+  if (process.env.CACHE_HIT_RATE) {
+    const {hit, miss} = decoder.keyDecoder;
+    console.log(`CACHE_HIT_RATE: cache hit rate in CachedKeyDecoder: hit=${hit}, hiss=${miss}, hit rate=${hit / (hit + miss)}`);
+  }
 }
 
 if (msgpack_js_v5) {

--- a/benchmark/benchmark-from-msgpack-lite.ts
+++ b/benchmark/benchmark-from-msgpack-lite.ts
@@ -8,7 +8,6 @@ var msgpack_lite = try_require("msgpack-lite");
 var msgpack_js = try_require("msgpack-js");
 var msgpack_js_v5 = try_require("msgpack-js-v5");
 var msgpack5 = try_require("msgpack5");
-var msgpack_unpack = try_require("msgpack-unpack");
 var notepack = try_require("notepack");
 
 msgpack5 = msgpack5 && msgpack5();
@@ -64,6 +63,12 @@ if (msgpack_msgpack) {
   buf = bench('buf = require("@msgpack/msgpack").encode(obj);', msgpack_msgpack.encode, data);
   obj = bench('obj = require("@msgpack/msgpack").decode(buf);', msgpack_msgpack.decode, buf);
   runTest(obj);
+
+  const encoder = new msgpack_msgpack.Encoder();
+  const decoder = new msgpack_msgpack.Decoder();
+  buf = bench('buf = /* @msgpack/msgpack */ encoder.encode(obj);', (data) => encoder.encode(data), data);
+  obj = bench('obj = /* @msgpack/msgpack */ decoder.decodeSync(buf);', (buf) => decoder.decodeSync(buf), buf);
+  runTest(obj);
 }
 
 if (msgpack_js_v5) {
@@ -87,11 +92,6 @@ if (msgpack5) {
 if (notepack) {
   buf = bench('buf = require("notepack").encode(obj);', notepack.encode, data);
   obj = bench('obj = require("notepack").decode(buf);', notepack.decode, buf);
-  runTest(obj);
-}
-
-if (msgpack_unpack) {
-  obj = bench('obj = require("msgpack-unpack").decode(buf);', msgpack_unpack, packed);
   runTest(obj);
 }
 

--- a/src/CachedKeyDecoder.ts
+++ b/src/CachedKeyDecoder.ts
@@ -8,7 +8,14 @@ interface KeyCacheRecord {
 const DEFAULT_MAX_KEY_LENGTH = 16;
 const DEFAULT_MAX_LENGTH_PER_KEY = 16;
 
-export class CachedKeyDecoder {
+export interface KeyDecoder {
+  canBeCached(byteLength: number): boolean;
+  decode(bytes: Uint8Array, inputOffset: number, byteLength: number): string;
+}
+
+export class CachedKeyDecoder implements KeyDecoder {
+  hit = 0;
+  miss = 0;
   private readonly caches: Array<Array<KeyCacheRecord>>;
 
   constructor(readonly maxKeyLength = DEFAULT_MAX_KEY_LENGTH, readonly maxLengthPerKey = DEFAULT_MAX_LENGTH_PER_KEY) {
@@ -57,8 +64,10 @@ export class CachedKeyDecoder {
   public decode(bytes: Uint8Array, inputOffset: number, byteLength: number): string {
     const cachedValue = this.get(bytes, inputOffset, byteLength);
     if (cachedValue != null) {
+      this.hit++;
       return cachedValue;
     }
+    this.miss++;
 
     const value = utf8DecodeJs(bytes, inputOffset, byteLength);
     // Ensure to copy a slice of bytes because the byte may be NodeJS Buffer and Buffer#slice() returns a reference to its internal ArrayBuffer.

--- a/src/Decoder.ts
+++ b/src/Decoder.ts
@@ -91,7 +91,7 @@ export class Decoder<ContextType> {
     this.pos = 0;
   }
 
-  public appendBuffer(buffer: ArrayLike<number>) {
+  private appendBuffer(buffer: ArrayLike<number>) {
     if (this.headByte === HEAD_BYTE_REQUIRED && !this.hasRemaining()) {
       this.setBuffer(buffer);
     } else {
@@ -114,11 +114,7 @@ export class Decoder<ContextType> {
     return new RangeError(`Extra ${view.byteLength - pos} of ${view.byteLength} byte(s) found at buffer[${posToShow}]`);
   }
 
-  /**
-   * A synchronous interface to decode a byte buffer. It mutates the decoder instance.
-   * @param buffer A byte buffer encoded in MessagePack.
-   */
-  public decodeSync(buffer: ArrayLike<number> | ArrayBuffer): unknown {
+  public decode(buffer: ArrayLike<number> | ArrayBuffer): unknown {
     this.reinitializeState();
     this.setBuffer(buffer);
     return this.doDecodeSingleSync();

--- a/src/Decoder.ts
+++ b/src/Decoder.ts
@@ -3,7 +3,7 @@ import { ExtensionCodec, ExtensionCodecType } from "./ExtensionCodec";
 import { getInt64, getUint64 } from "./utils/int";
 import { utf8DecodeJs, TEXT_ENCODING_AVAILABLE, TEXT_DECODER_THRESHOLD, utf8DecodeTD } from "./utils/utf8";
 import { createDataView, ensureUint8Array } from "./utils/typedArrays";
-import { CachedKeyDecoder } from "./CachedKeyDecoder";
+import { CachedKeyDecoder, KeyDecoder } from "./CachedKeyDecoder";
 
 const enum State {
   ARRAY,
@@ -77,7 +77,7 @@ export class Decoder<ContextType> {
     readonly maxArrayLength = DEFAULT_MAX_LENGTH,
     readonly maxMapLength = DEFAULT_MAX_LENGTH,
     readonly maxExtLength = DEFAULT_MAX_LENGTH,
-    readonly cachedKeyDecoder: CachedKeyDecoder | null = sharedCachedKeyDecoder,
+    readonly keyDecoder: KeyDecoder | null = sharedCachedKeyDecoder,
   ) {}
 
   private reinitializeState() {
@@ -494,8 +494,8 @@ export class Decoder<ContextType> {
 
     const offset = this.pos + headerOffset;
     let object: string;
-    if (this.stateIsMapKey() && this.cachedKeyDecoder?.canBeCached(byteLength)) {
-      object = this.cachedKeyDecoder.decode(this.bytes, offset, byteLength);
+    if (this.stateIsMapKey() && this.keyDecoder?.canBeCached(byteLength)) {
+      object = this.keyDecoder.decode(this.bytes, offset, byteLength);
     } else if (TEXT_ENCODING_AVAILABLE && byteLength > TEXT_DECODER_THRESHOLD) {
       object = utf8DecodeTD(this.bytes, offset, byteLength);
     } else {

--- a/src/Decoder.ts
+++ b/src/Decoder.ts
@@ -132,7 +132,7 @@ export class Decoder<ContextType> {
     return object;
   }
 
-  public async decodeSingleAsync(stream: AsyncIterable<ArrayLike<number>>): Promise<unknown> {
+  public async decodeAsync(stream: AsyncIterable<ArrayLike<number>>): Promise<unknown> {
     let decoded = false;
     let object: unknown;
     for await (const buffer of stream) {

--- a/src/Decoder.ts
+++ b/src/Decoder.ts
@@ -70,8 +70,8 @@ export class Decoder<ContextType> {
   private readonly stack: Array<StackState> = [];
 
   public constructor(
-    private readonly context: ContextType,
     private readonly extensionCodec: ExtensionCodecType<ContextType> = ExtensionCodec.defaultCodec as any,
+    private readonly context: ContextType = undefined as any,
     private readonly maxStrLength = DEFAULT_MAX_LENGTH,
     private readonly maxBinLength = DEFAULT_MAX_LENGTH,
     private readonly maxArrayLength = DEFAULT_MAX_LENGTH,

--- a/src/Encoder.ts
+++ b/src/Encoder.ts
@@ -22,7 +22,7 @@ export class Encoder<ContextType> {
     private readonly ignoreUndefined = false,
   ) {}
 
-  public getUint8Array(): Uint8Array {
+  private getUint8Array(): Uint8Array {
     return this.bytes.subarray(0, this.pos);
   }
 

--- a/src/Encoder.ts
+++ b/src/Encoder.ts
@@ -13,8 +13,8 @@ export class Encoder<ContextType> {
   private bytes = new Uint8Array(this.view.buffer);
 
   constructor(
-    readonly extensionCodec: ExtensionCodecType<ContextType> = ExtensionCodec.defaultCodec as any,
     readonly context: ContextType,
+    readonly extensionCodec: ExtensionCodecType<ContextType> = ExtensionCodec.defaultCodec as any,
     readonly maxDepth = DEFAULT_MAX_DEPTH,
     readonly initialBufferSize = DEFAULT_INITIAL_BUFFER_SIZE,
     readonly sortKeys = false,
@@ -22,7 +22,17 @@ export class Encoder<ContextType> {
     readonly ignoreUndefined = false,
   ) {}
 
-  encode(object: unknown, depth: number): void {
+  private reinitializeState() {
+    this.pos = 0;
+  }
+
+  encode(object: unknown): Uint8Array {
+    this.reinitializeState();
+    this.doEncode(object, 1);
+    return this.getUint8Array();
+  }
+
+  doEncode(object: unknown, depth: number): void {
     if (depth > this.maxDepth) {
       throw new Error(`Too deep objects in depth ${depth}`);
     }
@@ -228,7 +238,7 @@ export class Encoder<ContextType> {
       throw new Error(`Too large array: ${size}`);
     }
     for (const item of object) {
-      this.encode(item, depth + 1);
+      this.doEncode(item, depth + 1);
     }
   }
 
@@ -272,7 +282,7 @@ export class Encoder<ContextType> {
 
       if (!(this.ignoreUndefined && value === undefined)) {
         this.encodeString(key);
-        this.encode(value, depth + 1);
+        this.doEncode(value, depth + 1);
       }
     }
   }

--- a/src/Encoder.ts
+++ b/src/Encoder.ts
@@ -13,8 +13,8 @@ export class Encoder<ContextType> {
   private bytes = new Uint8Array(this.view.buffer);
 
   public constructor(
-    private readonly context: ContextType,
     private readonly extensionCodec: ExtensionCodecType<ContextType> = ExtensionCodec.defaultCodec as any,
+    private readonly context: ContextType = undefined as any,
     private readonly maxDepth = DEFAULT_MAX_DEPTH,
     private readonly initialBufferSize = DEFAULT_INITIAL_BUFFER_SIZE,
     private readonly sortKeys = false,

--- a/src/Encoder.ts
+++ b/src/Encoder.ts
@@ -12,27 +12,31 @@ export class Encoder<ContextType> {
   private view = new DataView(new ArrayBuffer(this.initialBufferSize));
   private bytes = new Uint8Array(this.view.buffer);
 
-  constructor(
-    readonly context: ContextType,
-    readonly extensionCodec: ExtensionCodecType<ContextType> = ExtensionCodec.defaultCodec as any,
-    readonly maxDepth = DEFAULT_MAX_DEPTH,
-    readonly initialBufferSize = DEFAULT_INITIAL_BUFFER_SIZE,
-    readonly sortKeys = false,
-    readonly forceFloat32 = false,
-    readonly ignoreUndefined = false,
+  public constructor(
+    private readonly context: ContextType,
+    private readonly extensionCodec: ExtensionCodecType<ContextType> = ExtensionCodec.defaultCodec as any,
+    private readonly maxDepth = DEFAULT_MAX_DEPTH,
+    private readonly initialBufferSize = DEFAULT_INITIAL_BUFFER_SIZE,
+    private readonly sortKeys = false,
+    private readonly forceFloat32 = false,
+    private readonly ignoreUndefined = false,
   ) {}
+
+  public getUint8Array(): Uint8Array {
+    return this.bytes.subarray(0, this.pos);
+  }
 
   private reinitializeState() {
     this.pos = 0;
   }
 
-  encode(object: unknown): Uint8Array {
+  public encode(object: unknown): Uint8Array {
     this.reinitializeState();
     this.doEncode(object, 1);
     return this.getUint8Array();
   }
 
-  doEncode(object: unknown, depth: number): void {
+  private doEncode(object: unknown, depth: number): void {
     if (depth > this.maxDepth) {
       throw new Error(`Too deep objects in depth ${depth}`);
     }
@@ -50,11 +54,7 @@ export class Encoder<ContextType> {
     }
   }
 
-  getUint8Array(): Uint8Array {
-    return this.bytes.subarray(0, this.pos);
-  }
-
-  ensureBufferSizeToWrite(sizeToWrite: number) {
+  private ensureBufferSizeToWrite(sizeToWrite: number) {
     const requiredSize = this.pos + sizeToWrite;
 
     if (this.view.byteLength < requiredSize) {
@@ -62,7 +62,7 @@ export class Encoder<ContextType> {
     }
   }
 
-  resizeBuffer(newSize: number) {
+  private resizeBuffer(newSize: number) {
     const newBuffer = new ArrayBuffer(newSize);
     const newBytes = new Uint8Array(newBuffer);
     const newView = new DataView(newBuffer);
@@ -73,18 +73,18 @@ export class Encoder<ContextType> {
     this.bytes = newBytes;
   }
 
-  encodeNil() {
+  private encodeNil() {
     this.writeU8(0xc0);
   }
 
-  encodeBoolean(object: boolean) {
+  private encodeBoolean(object: boolean) {
     if (object === false) {
       this.writeU8(0xc2);
     } else {
       this.writeU8(0xc3);
     }
   }
-  encodeNumber(object: number) {
+  private encodeNumber(object: number) {
     if (Number.isSafeInteger(object)) {
       if (object >= 0) {
         if (object < 0x80) {
@@ -143,7 +143,7 @@ export class Encoder<ContextType> {
     }
   }
 
-  writeStringHeader(byteLength: number) {
+  private writeStringHeader(byteLength: number) {
     if (byteLength < 32) {
       // fixstr
       this.writeU8(0xa0 + byteLength);
@@ -164,7 +164,7 @@ export class Encoder<ContextType> {
     }
   }
 
-  encodeString(object: string) {
+  private encodeString(object: string) {
     const maxHeaderSize = 1 + 4;
     const strLength = object.length;
 
@@ -183,7 +183,7 @@ export class Encoder<ContextType> {
     }
   }
 
-  encodeObject(object: unknown, depth: number) {
+  private encodeObject(object: unknown, depth: number) {
     // try to encode objects with custom codec first of non-primitives
     const ext = this.extensionCodec.tryToEncode(object, this.context);
     if (ext != null) {
@@ -200,7 +200,7 @@ export class Encoder<ContextType> {
     }
   }
 
-  encodeBinary(object: ArrayBufferView) {
+  private encodeBinary(object: ArrayBufferView) {
     const size = object.byteLength;
     if (size < 0x100) {
       // bin 8
@@ -221,7 +221,7 @@ export class Encoder<ContextType> {
     this.writeU8a(bytes);
   }
 
-  encodeArray(object: Array<unknown>, depth: number) {
+  private encodeArray(object: Array<unknown>, depth: number) {
     const size = object.length;
     if (size < 16) {
       // fixarray
@@ -242,7 +242,7 @@ export class Encoder<ContextType> {
     }
   }
 
-  countWithoutUndefined(object: Record<string, unknown>, keys: ReadonlyArray<string>): number {
+  private countWithoutUndefined(object: Record<string, unknown>, keys: ReadonlyArray<string>): number {
     let count = 0;
 
     for (const key of keys) {
@@ -254,7 +254,7 @@ export class Encoder<ContextType> {
     return count;
   }
 
-  encodeMap(object: Record<string, unknown>, depth: number) {
+  private encodeMap(object: Record<string, unknown>, depth: number) {
     const keys = Object.keys(object);
     if (this.sortKeys) {
       keys.sort();
@@ -287,7 +287,7 @@ export class Encoder<ContextType> {
     }
   }
 
-  encodeExtension(ext: ExtData) {
+  private encodeExtension(ext: ExtData) {
     const size = ext.data.length;
     if (size === 1) {
       // fixext 1
@@ -323,14 +323,14 @@ export class Encoder<ContextType> {
     this.writeU8a(ext.data);
   }
 
-  writeU8(value: number) {
+  private writeU8(value: number) {
     this.ensureBufferSizeToWrite(1);
 
     this.view.setUint8(this.pos, value);
     this.pos++;
   }
 
-  writeU8a(values: ArrayLike<number>) {
+  private writeU8a(values: ArrayLike<number>) {
     const size = values.length;
     this.ensureBufferSizeToWrite(size);
 
@@ -338,61 +338,61 @@ export class Encoder<ContextType> {
     this.pos += size;
   }
 
-  writeI8(value: number) {
+  private writeI8(value: number) {
     this.ensureBufferSizeToWrite(1);
 
     this.view.setInt8(this.pos, value);
     this.pos++;
   }
 
-  writeU16(value: number) {
+  private writeU16(value: number) {
     this.ensureBufferSizeToWrite(2);
 
     this.view.setUint16(this.pos, value);
     this.pos += 2;
   }
 
-  writeI16(value: number) {
+  private writeI16(value: number) {
     this.ensureBufferSizeToWrite(2);
 
     this.view.setInt16(this.pos, value);
     this.pos += 2;
   }
 
-  writeU32(value: number) {
+  private writeU32(value: number) {
     this.ensureBufferSizeToWrite(4);
 
     this.view.setUint32(this.pos, value);
     this.pos += 4;
   }
 
-  writeI32(value: number) {
+  private writeI32(value: number) {
     this.ensureBufferSizeToWrite(4);
 
     this.view.setInt32(this.pos, value);
     this.pos += 4;
   }
 
-  writeF32(value: number) {
+  private writeF32(value: number) {
     this.ensureBufferSizeToWrite(4);
     this.view.setFloat32(this.pos, value);
     this.pos += 4;
   }
 
-  writeF64(value: number) {
+  private writeF64(value: number) {
     this.ensureBufferSizeToWrite(8);
     this.view.setFloat64(this.pos, value);
     this.pos += 8;
   }
 
-  writeU64(value: number) {
+  private writeU64(value: number) {
     this.ensureBufferSizeToWrite(8);
 
     setUint64(this.view, this.pos, value);
     this.pos += 8;
   }
 
-  writeI64(value: number) {
+  private writeI64(value: number) {
     this.ensureBufferSizeToWrite(8);
 
     setInt64(this.view, this.pos, value);

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -47,14 +47,13 @@ export function decode<ContextType>(
   options: DecodeOptions<SplitUndefined<ContextType>> = defaultDecodeOptions as any,
 ): unknown {
   const decoder = new Decoder<ContextType>(
-    options.extensionCodec,
     (options as typeof options & { context: any }).context,
+    options.extensionCodec,
     options.maxStrLength,
     options.maxBinLength,
     options.maxArrayLength,
     options.maxMapLength,
     options.maxExtLength,
   );
-  decoder.setBuffer(buffer); // decodeSync() requires only one buffer
-  return decoder.decodeSingleSync();
+  return decoder.decodeSync(buffer);
 }

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -55,5 +55,5 @@ export function decode<ContextType>(
     options.maxMapLength,
     options.maxExtLength,
   );
-  return decoder.decodeSync(buffer);
+  return decoder.decode(buffer);
 }

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -47,8 +47,8 @@ export function decode<ContextType>(
   options: DecodeOptions<SplitUndefined<ContextType>> = defaultDecodeOptions as any,
 ): unknown {
   const decoder = new Decoder<ContextType>(
-    (options as typeof options & { context: any }).context,
     options.extensionCodec,
+    (options as typeof options & { context: any }).context,
     options.maxStrLength,
     options.maxBinLength,
     options.maxArrayLength,

--- a/src/decodeAsync.ts
+++ b/src/decodeAsync.ts
@@ -18,7 +18,7 @@ export async function decodeAsync<ContextType>(
     options.maxMapLength,
     options.maxExtLength,
   );
-  return decoder.decodeSingleAsync(stream);
+  return decoder.decodeAsync(stream);
 }
 
 export function decodeArrayStream<ContextType>(

--- a/src/decodeAsync.ts
+++ b/src/decodeAsync.ts
@@ -10,8 +10,8 @@ export async function decodeAsync<ContextType>(
   const stream = ensureAsyncIterabe(streamLike);
 
   const decoder = new Decoder<ContextType>(
-    options.extensionCodec,
     (options as typeof options & { context: any }).context,
+    options.extensionCodec,
     options.maxStrLength,
     options.maxBinLength,
     options.maxArrayLength,
@@ -28,8 +28,8 @@ export function decodeArrayStream<ContextType>(
   const stream = ensureAsyncIterabe(streamLike);
 
   const decoder = new Decoder<ContextType>(
-    options.extensionCodec,
     (options as typeof options & { context: any }).context,
+    options.extensionCodec,
     options.maxStrLength,
     options.maxBinLength,
     options.maxArrayLength,
@@ -47,8 +47,8 @@ export function decodeStream<ContextType>(
   const stream = ensureAsyncIterabe(streamLike);
 
   const decoder = new Decoder<ContextType>(
-    options.extensionCodec,
     (options as typeof options & { context: any }).context,
+    options.extensionCodec,
     options.maxStrLength,
     options.maxBinLength,
     options.maxArrayLength,

--- a/src/decodeAsync.ts
+++ b/src/decodeAsync.ts
@@ -10,8 +10,8 @@ export async function decodeAsync<ContextType>(
   const stream = ensureAsyncIterabe(streamLike);
 
   const decoder = new Decoder<ContextType>(
-    (options as typeof options & { context: any }).context,
     options.extensionCodec,
+    (options as typeof options & { context: any }).context,
     options.maxStrLength,
     options.maxBinLength,
     options.maxArrayLength,
@@ -28,8 +28,8 @@ export function decodeArrayStream<ContextType>(
   const stream = ensureAsyncIterabe(streamLike);
 
   const decoder = new Decoder<ContextType>(
-    (options as typeof options & { context: any }).context,
     options.extensionCodec,
+    (options as typeof options & { context: any }).context,
     options.maxStrLength,
     options.maxBinLength,
     options.maxArrayLength,
@@ -47,8 +47,8 @@ export function decodeStream<ContextType>(
   const stream = ensureAsyncIterabe(streamLike);
 
   const decoder = new Decoder<ContextType>(
-    (options as typeof options & { context: any }).context,
     options.extensionCodec,
+    (options as typeof options & { context: any }).context,
     options.maxStrLength,
     options.maxBinLength,
     options.maxArrayLength,

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -40,14 +40,13 @@ export function encode<ContextType>(
   options: EncodeOptions<SplitUndefined<ContextType>> = defaultEncodeOptions as any,
 ): Uint8Array {
   const encoder = new Encoder<ContextType>(
-    options.extensionCodec,
     (options as typeof options & { context: any }).context,
+    options.extensionCodec,
     options.maxDepth,
     options.initialBufferSize,
     options.sortKeys,
     options.forceFloat32,
     options.ignoreUndefined,
   );
-  encoder.encode(value, 1);
-  return encoder.getUint8Array();
+  return encoder.encode(value);
 }

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -40,8 +40,8 @@ export function encode<ContextType>(
   options: EncodeOptions<SplitUndefined<ContextType>> = defaultEncodeOptions as any,
 ): Uint8Array {
   const encoder = new Encoder<ContextType>(
-    (options as typeof options & { context: any }).context,
     options.extensionCodec,
+    (options as typeof options & { context: any }).context,
     options.maxDepth,
     options.initialBufferSize,
     options.sortKeys,

--- a/test/reuse-instances.test.ts
+++ b/test/reuse-instances.test.ts
@@ -1,0 +1,41 @@
+import { deepStrictEqual } from "assert";
+import { Encoder, Decoder } from "@msgpack/msgpack";
+
+describe("shared instances", () => {
+  context("Encoder and Decoder", () => {
+    const encoder = new Encoder(undefined);
+    const decoder = new Decoder(undefined);
+
+    it("runs #1", () => {
+      const object = {
+        nil: null,
+        integer: 1,
+        float: Math.PI,
+        string: "Hello, world!",
+        binary: Uint8Array.from([1, 2, 3]),
+        array: [10, 20, 30],
+        map: { foo: "bar" },
+        timestampExt: new Date(),
+      };
+
+      const encoded: Uint8Array = encoder.encode(object);
+      deepStrictEqual(decoder.decodeSync(encoded), object);
+    });
+
+    it("runs #2", () => {
+      const object = {
+        nil: null,
+        integer: 1,
+        float: Math.PI,
+        string: "Hello, world!",
+        binary: Uint8Array.from([1, 2, 3]),
+        array: [10, 20, 30],
+        map: { foo: "bar" },
+        timestampExt: new Date(),
+      };
+
+      const encoded: Uint8Array = encoder.encode(object);
+      deepStrictEqual(decoder.decodeSync(encoded), object);
+    });
+  });
+});

--- a/test/reuse-instances.test.ts
+++ b/test/reuse-instances.test.ts
@@ -25,7 +25,7 @@ describe("shared instances", () => {
       };
 
       const encoded: Uint8Array = encoder.encode(object);
-      deepStrictEqual(decoder.decodeSync(encoded), object);
+      deepStrictEqual(decoder.decode(encoded), object);
     });
 
     it("runs #2", () => {
@@ -41,7 +41,7 @@ describe("shared instances", () => {
       };
 
       const encoded: Uint8Array = encoder.encode(object);
-      deepStrictEqual(decoder.decodeSync(encoded), object);
+      deepStrictEqual(decoder.decode(encoded), object);
     });
   });
 

--- a/test/reuse-instances.test.ts
+++ b/test/reuse-instances.test.ts
@@ -9,8 +9,8 @@ const createStream = async function* (...args: any) {
 
 describe("shared instances", () => {
   context("encode() and decodeSync()", () => {
-    const encoder = new Encoder(undefined);
-    const decoder = new Decoder(undefined);
+    const encoder = new Encoder();
+    const decoder = new Decoder();
 
     it("runs #1", () => {
       const object = {
@@ -46,8 +46,8 @@ describe("shared instances", () => {
   });
 
   context("encode() and decodeAsync()", () => {
-    const encoder = new Encoder(undefined);
-    const decoder = new Decoder(undefined);
+    const encoder = new Encoder();
+    const decoder = new Decoder();
 
     it("runs #1", async () => {
       const object = {
@@ -83,8 +83,8 @@ describe("shared instances", () => {
   });
 
   context("encode() and decodeStream()", () => {
-    const encoder = new Encoder(undefined);
-    const decoder = new Decoder(undefined);
+    const encoder = new Encoder();
+    const decoder = new Decoder();
 
     it("runs #1", async () => {
       const object = {
@@ -128,8 +128,8 @@ describe("shared instances", () => {
   });
 
   context("encode() and decodeArrayStream()", () => {
-    const encoder = new Encoder(undefined);
-    const decoder = new Decoder(undefined);
+    const encoder = new Encoder();
+    const decoder = new Decoder();
 
     it("runs #1", async () => {
       const object = {

--- a/test/reuse-instances.test.ts
+++ b/test/reuse-instances.test.ts
@@ -1,8 +1,14 @@
 import { deepStrictEqual } from "assert";
 import { Encoder, Decoder } from "@msgpack/msgpack";
 
+const createStream = async function* (...args: any) {
+  for (const item of args) {
+    yield item;
+  }
+};
+
 describe("shared instances", () => {
-  context("Encoder and Decoder", () => {
+  context("encode() and decodeSync()", () => {
     const encoder = new Encoder(undefined);
     const decoder = new Decoder(undefined);
 
@@ -36,6 +42,133 @@ describe("shared instances", () => {
 
       const encoded: Uint8Array = encoder.encode(object);
       deepStrictEqual(decoder.decodeSync(encoded), object);
+    });
+  });
+
+  context("encode() and decodeAsync()", () => {
+    const encoder = new Encoder(undefined);
+    const decoder = new Decoder(undefined);
+
+    it("runs #1", async () => {
+      const object = {
+        nil: null,
+        integer: 1,
+        float: Math.PI,
+        string: "Hello, world!",
+        binary: Uint8Array.from([1, 2, 3]),
+        array: [10, 20, 30],
+        map: { foo: "bar" },
+        timestampExt: new Date(),
+      };
+
+      const encoded: Uint8Array = encoder.encode(object);
+      deepStrictEqual(await decoder.decodeAsync(createStream(encoded)), object);
+    });
+
+    it("runs #2", async () => {
+      const object = {
+        nil: null,
+        integer: 1,
+        float: Math.PI,
+        string: "Hello, world!",
+        binary: Uint8Array.from([1, 2, 3]),
+        array: [10, 20, 30],
+        map: { foo: "bar" },
+        timestampExt: new Date(),
+      };
+
+      const encoded: Uint8Array = encoder.encode(object);
+      deepStrictEqual(await decoder.decodeAsync(createStream(encoded)), object);
+    });
+  });
+
+  context("encode() and decodeStream()", () => {
+    const encoder = new Encoder(undefined);
+    const decoder = new Decoder(undefined);
+
+    it("runs #1", async () => {
+      const object = {
+        nil: null,
+        integer: 1,
+        float: Math.PI,
+        string: "Hello, world!",
+        binary: Uint8Array.from([1, 2, 3]),
+        array: [10, 20, 30],
+        map: { foo: "bar" },
+        timestampExt: new Date(),
+      };
+
+      const encoded: Uint8Array = encoder.encode(object);
+      const a: Array<any> = [];
+      for await (const item of decoder.decodeStream(createStream(encoded))) {
+        a.push(item);
+      }
+      deepStrictEqual(a, [object]);
+    });
+
+    it("runs #2", async () => {
+      const object = {
+        nil: null,
+        integer: 1,
+        float: Math.PI,
+        string: "Hello, world!",
+        binary: Uint8Array.from([1, 2, 3]),
+        array: [10, 20, 30],
+        map: { foo: "bar" },
+        timestampExt: new Date(),
+      };
+
+      const encoded: Uint8Array = encoder.encode(object);
+      const a: Array<any> = [];
+      for await (const item of decoder.decodeStream(createStream(encoded))) {
+        a.push(item);
+      }
+      deepStrictEqual(a, [object]);
+    });
+  });
+
+  context("encode() and decodeArrayStream()", () => {
+    const encoder = new Encoder(undefined);
+    const decoder = new Decoder(undefined);
+
+    it("runs #1", async () => {
+      const object = {
+        nil: null,
+        integer: 1,
+        float: Math.PI,
+        string: "Hello, world!",
+        binary: Uint8Array.from([1, 2, 3]),
+        array: [10, 20, 30],
+        map: { foo: "bar" },
+        timestampExt: new Date(),
+      };
+
+      const encoded: Uint8Array = encoder.encode([object]);
+      const a: Array<any> = [];
+      for await (const item of decoder.decodeStream(createStream(encoded))) {
+        a.push(item);
+      }
+      deepStrictEqual(a, [[object]]);
+    });
+
+    it("runs #2", async () => {
+      const object = {
+        nil: null,
+        integer: 1,
+        float: Math.PI,
+        string: "Hello, world!",
+        binary: Uint8Array.from([1, 2, 3]),
+        array: [10, 20, 30],
+        map: { foo: "bar" },
+        timestampExt: new Date(),
+      };
+
+      const encoded: Uint8Array = encoder.encode([object]);
+      const a: Array<any> = [];
+      for await (const item of decoder.decodeStream(createStream(encoded))) {
+        a.push(item);
+      }
+      deepStrictEqual(a, [[object]]);
     });
   });
 });


### PR DESCRIPTION
It changes the interfaces to Encoder and Decoder,  so I'll bump the major version on the next release.

## Benchmark Results

```
npx ts-node benchmark/benchmark-from-msgpack-lite.ts
Benchmark on NodeJS/v14.8.0 (V8/8.4)

operation                                                         |   op   |   ms  |  op/s
----------------------------------------------------------------- | ------: | ----: | ------:
buf = Buffer.from(JSON.stringify(obj));                           |  763800 |  5000 |  152760
buf = JSON.stringify(obj);                                        | 1086600 |  5000 |  217320
obj = JSON.parse(buf);                                            | 1634600 |  5000 |  326920
buf = require("msgpack-lite").encode(obj);                        |  462900 |  5000 |   92580
obj = require("msgpack-lite").decode(buf);                        |  271700 |  5001 |   54329
buf = require("@msgpack/msgpack").encode(obj);                    |  802400 |  5000 |  160480
obj = require("@msgpack/msgpack").decode(buf);                    |  724400 |  5000 |  144880
buf = /* @msgpack/msgpack */ encoder.encode(obj);                 | 1083000 |  5000 |  216600
obj = /* @msgpack/msgpack */ decoder.decode(buf);                 |  737500 |  5000 |  147500```