### PR TITLE
chore: invalid syntax in the example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,10 +280,7 @@ extensionCodec.register({
   },
 });
 
-// and later
-import { encode, decode } from "@msgpack/msgpack";
-
-const encoded = = encode([new Set<any>(), new Map<any, any>()], { extensionCodec });
+const encoded = encode([new Set<any>(), new Map<any, any>()], { extensionCodec });
 const decoded = decode(encoded, { extensionCodec });
 ```
 


### PR DESCRIPTION
# About

* removed duplicated import statement
* fixed invalid assignment statement

# Note

BTW, when I tries to run the example code for working with extension type, I have faced the following tsc compile error.

```
error TS2322: Type 'ExtensionCodec<MyContext>' is not assignable to type 'ExtensionCodecType<undefined>'.
  Types of property '__brand' are incompatible.
    Type 'MyContext' is not assignable to type 'undefined'.
```

I'm investigating the issue it right now. If there'll be something worth to be considered, I'll suggest another PR or raise up an issue.