### PR TITLE
[suggestion] chore: add annotation typescript usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,8 @@ This module requires definitions of `AsyncIterator` and whatwg streams, which is
 
 For the TypeScript version, the latest TypeScript is tested in development, but older versions of TypeScript might be able to compile this module.
 
+We also recommend enabling `strict` mode (or `strictNullCheck` mode at least). Specifically when you use `ExtensionCodec` with the ContextType that you defines, the type checking for `EncodeOptions` argument of `encode` function and `DecodeOptions` arugument of `decode` function will fail because ts compiler cannot infer the `EncodeOptions`/`DecodeOptions` generic type appropriately unless `strictNullChecks` property is set to be `true` in `tsconfig.json`.
+
 ## Benchmark
 
 Run-time performance is not the only reason to use MessagePack, but it's important to choose MessagePack libraries, so a benchmark suite is provided to monitor the performance of this library.


### PR DESCRIPTION
# About

recommend enabling `strict` mode for avoiding type checking failure when using this library in TypeScript project.

# Background

As I mentioned in https://github.com/msgpack/msgpack-javascript/pull/135 , I found the circumstance where the type checking for encode/decode function call fails.

That specifically happens when user defined context type is given to the ExtensionCodec.

```
const extensionCodec = new ExtensionCodec<UserDefinedContext>();
```

# Solution

Set `compilerOptions.strictNullChecks` to `true` in `tsconfig.json`. 

# Acknowledgement

I'm not so familiar with TypeScript and still don't understand why this issue happens. (I'll follow up this phenomenon for my interest later)