### PR TITLE
[proposal] fix: type check issues on encod/decode arguments

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -1,6 +1,9 @@
 /* eslint-disable @typescript-eslint/ban-types */
 
-export type SplitTypes<T, U> = U extends T ? U : Exclude<T, U>;
+export type SplitTypes<T, U> = U extends T
+    ? Exclude<T, U> extends never ? T : Exclude<T, U>
+    : T;
+
 export type SplitUndefined<T> = SplitTypes<T, undefined>;
 
 export type ContextOf<ContextType> = ContextType extends undefined

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -42,11 +42,11 @@ export const defaultDecodeOptions: DecodeOptions = {};
  *
  * This is a synchronous decoding function. See other variants for asynchronous decoding: `decodeAsync()`, `decodeStream()`, `decodeArrayStream()`.
  */
-export function decode<ContextType>(
+export function decode<ContextType = undefined>(
   buffer: ArrayLike<number> | ArrayBuffer,
   options: DecodeOptions<SplitUndefined<ContextType>> = defaultDecodeOptions as any,
 ): unknown {
-  const decoder = new Decoder<ContextType>(
+  const decoder = new Decoder(
     options.extensionCodec,
     (options as typeof options & { context: any }).context,
     options.maxStrLength,

--- a/src/decodeAsync.ts
+++ b/src/decodeAsync.ts
@@ -9,7 +9,7 @@ export async function decodeAsync<ContextType>(
 ): Promise<unknown> {
   const stream = ensureAsyncIterabe(streamLike);
 
-  const decoder = new Decoder<ContextType>(
+  const decoder = new Decoder(
     options.extensionCodec,
     (options as typeof options & { context: any }).context,
     options.maxStrLength,
@@ -27,7 +27,7 @@ export function decodeArrayStream<ContextType>(
 ) {
   const stream = ensureAsyncIterabe(streamLike);
 
-  const decoder = new Decoder<ContextType>(
+  const decoder = new Decoder(
     options.extensionCodec,
     (options as typeof options & { context: any }).context,
     options.maxStrLength,
@@ -46,7 +46,7 @@ export function decodeStream<ContextType>(
 ) {
   const stream = ensureAsyncIterabe(streamLike);
 
-  const decoder = new Decoder<ContextType>(
+  const decoder = new Decoder(
     options.extensionCodec,
     (options as typeof options & { context: any }).context,
     options.maxStrLength,

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -43,11 +43,11 @@ const defaultEncodeOptions: EncodeOptions = {};
  *
  * The returned buffer is a slice of a larger `ArrayBuffer`, so you have to use its `#byteOffset` and `#byteLength` in order to convert it to another typed arrays including NodeJS `Buffer`.
  */
-export function encode<ContextType>(
+export function encode<ContextType = undefined>(
   value: unknown,
   options: EncodeOptions<SplitUndefined<ContextType>> = defaultEncodeOptions as any,
 ): Uint8Array {
-  const encoder = new Encoder<ContextType>(
+  const encoder = new Encoder(
     options.extensionCodec,
     (options as typeof options & { context: any }).context,
     options.maxDepth,


### PR DESCRIPTION
# About

This PR intends to fix the issue reported on #136 , where I described the workaround for avoiding type check error in TypeScript.

The goal of this PR is making msgpack-javascript available from TypeScript both with/without enabling `strictNullCheck` compile option.

Since I don't know the actual intention of the original implementer ( @grantila ),  the change in this PR might be controversial.

So, though it would be appreciated if you welcome this PR, I highly recommend to ask @grantila 's opinion.

# Background

## Issue of the current implementation

https://github.com/msgpack/msgpack-javascript/blob/8ba75f85cc45048dc8b7ab7dad623740dcc3a656/src/context.ts#L3

I think this implementation has some issues.

### issue of `SplitTypes` when `strictNullCheck` is disabled:

[This short code](https://www.typescriptlang.org/play?strictNullChecks=false#code/PTAEHUAsFMDtQM4BcBOBLAxkgcgVwDb4DCMGA1qGgqACZUCGARvtDQFBtICeADtKAGUe+NEgA8AFQA0oAKoA+UAF45oaAA8kcGtQmgA-KoBcoAKLqM+XDWiSZCgNxsQg4aNmwbAMzSxWkxSpQenwAd3ouamgANxDcei0aYOoAAz9o6BQU0EZoDHpcBH4U3E9oHz8abKCEXEZuPlAAey9gwmakGBRQBuhqUJh4FOR0LDxCEjyyauo6BCYWdhci-kgkJB4EIxBQ3YA6XoQMdB4kfHpYAHM9ppRL4BomjARgSAuaRiamsmBGegRMABaQ57NYAW3wAGJYAR8ID3oDSt5fKxOLx+EIREgPMjKgFlK4sXZQEjyiiaPIOGwWEhgiZMe4yhV-KTmRSCazyU5nGAQvgejBQF4moQmqFfJdQLF0As+sEUPwYnEEqxkqA0jFMtletToLTGPS3NimeSxDCwbkUPInDTQBhDVicWS8ebLaAAD4kk2Va0cIA) describes the issue.
 
As I wrote in the inline comment, given `type Split<T, U> = U extends T ? U : Exclude<T, U>`, `Split<T, undefined>` is always evaluated as `never` unless `T` is `undefined` because `undefined` is subtype of all other types when `strictNullCheck` is disabled. (see [TypeScript: Handbook \- Basic Types](https://www.typescriptlang.org/docs/handbook/basic-types.html#null-and-undefined))

This behavior is the cause of the issue that i reported in #136.

Lets say, if you write the following code in this circumstance:

```
const extensionCodec = new ExtensionCodec<MyContext>();
// snip...
const context = new MyContext();
const encoded = encode({new MyType(), { extensionCodec, context });
```

This code wouldn't be able to compiled as I reported.

The reason can be seen by gradually evaluating `encode({myType: new MyType<any>()}, { extensionCodec, context });`:

```
encode({myType: new MyType<any>()}, { extensionCodec, context });
// => encode<MyContext>(unknown, { ExtensionCodecType<MyContext>, context });
// => encode<MyContext>(unknown, EncodeOptions<SplitUndefined<MyContext>>)
// => encode(unknown, EncodeOptions<never>)
// { extensionCodec, context } doesn't match EncodeOptions<never>
```

[This code](https://www.typescriptlang.org/play?strictNullChecks=false#code/PTAEHUAsFMDtQM4BcBOBLAxkgcgVwDb4DCMGA1qGgqACZUCGARvtDQFBtICeADtKAGUe+NEgA8AFQA0oAKoA+UAF45oaAA8kcGtQmgA-KoBcoAKLqM+XDWiSZCgNyde-ISKSzYNgGZpYrSUUVN1E7UFwvaF9-GnkObj5QAElA5VAAb1B1fRM9AF94l1AADQB7b1SVPQ0tL2oInz9WAwy80BNM9VzQAudEgE1JNIaopti0gAV6FCQ0enwxTLQTFIl5GVgTWFwAW0ZoFB7FADIS8sCObwisNFL4b1hV+QAKNBzkwIBKDNAMO4RSiwAHT4UoAc1enwcPUu11md1AD0Ga2eXBMgxCHki0QCayCrVA9Go9FgXG+mQeT1RQLQUJhbEsROoRCGKhGOPGaB2wmgOzgSGoTx+2W6vT+sGQvwADGl-AB3UBEZ5Qhn-JCgLhS9FpJYmDAygpI1FSlVG3XSnqfDjiyUYACMsugCpZyHQsDBLytNvVXDt6LErr8Hp1lD1dpkXVAACJ6FGYUbfXSQKAYCh+HK0IRQPtfqVuZn+AcUKVDhEWAhqIGsHhCCRoORKNQ4EwWOwzaHfuGsiYY3G8lagA) emulates the issue of the actual code.

### above issue can be resolved when `strictNullCheck` is enabled, but ...

So, by enabling `strictNullCheck`, this issue can be solved as I reported in #136.

But, this is not ideal because client code is forced to enable `strictNullCheck`.

I was wondering if it's possible to achieve the goal (using msgpack-javascript by TypeScript without enabling `strictNullCheck` and without changing its API).

Then, I found one weird behavior of `SplitTypes` when the `strictNullCheck` is enabled.

```
// When strictNullCheck is enabled
type Split<T, U> = U extends T ? U : Exclude<T, U>;
type SplitUndefined<T> = Split<T, undefined>

let a: SplitUndefined<undefined> = undefined;
let b: SplitUndefined<number> = 1;

// SplitUndefined<number | undefined> is undefined
let c: SplitUndefined<number | undefined> = undefined
let d: SplitUndefined<number | undefined> = 1 // error
```
(actual code is [here](https://www.typescriptlang.org/play?#code/PTAEHUAsFMDtQM4BcBOBLAxkgcgVwDb4DCMGA1qGgqHAIYBG+0AJgFBICeADtKAMpd8aJAB4AKgBpQAVQB8oALwyaADyRxm1MaAD8ygFygAoioz5czaOKlyA3O268BQpNNiWAZmlgtx8pc7C1qC47tBePsyyrKxMSKC0hoGuYRG+oZ7eLP4hqVnM9nGg9EmCwm6ZkSKwuAC29NAoOQCM9qwg-GUplb419Y2gAD65PVGU1Bnh+bHQ8RilLhVTVX0NKEMjy9mKm2lsRcwL5XkrdWsbk3stoB2NKAD2KKxAA))

For me, given the name `SplitUndefined`, I felt weird if `SplitUndefined<number | undefined>` is evaluated as `undefined`. Rather, it seems natural for `SplitUndefined<number | undefined>` to be evaluated as `number`, for me.

Besides, `Split<T, U> = U extends T ? U : Exclude<T, U>` seems logically incorrect.
Given U is not subtype of T, T won't be the Union Type that contains U. Thus, `Exclude<T, U>` never excludes `U`.

So, I started to think this is the bug that @grantila ( original implementer of this code ) didn't intend.

It's really long and winding explanation, that was the story I addressed this PR.

# About the changes

Essential change in this PR is the following change.

https://github.com/msgpack/msgpack-javascript/pull/139/files#diff-a7af09f7fa8732629ff9579258b5584bR3

The behavior of this Code is like following code:

```
export type SplitTypes<T, U> = U extends T
    ? Exclude<T, U> extends never ? T : Exclude<T, U>
    : T;

export type SplitUndefined<T> = SplitTypes<T, undefined>;
let a: SplitUndefined<undefined> = undefined;
let b: SplitUndefined<number> = 1;

// SplitUndefined<number | undefined> is undefined
let c: SplitUndefined<number | undefined> = undefined // error
let d: SplitUndefined<number | undefined> = 1
```

This code behave same regardless of the state of `strictNullCheck`

* [When `strictNullCheck` is enabled](https://www.typescriptlang.org/play?#code/PTAEHUAsFMDtQM4BcBOBLAxkgcgVwDb4DCMGA1qGgqHAIYBG+0AJgFDQAeADgPYpKgkATy7RQAZS740SACojoCADyyANKACqAPlABeTTQ5I4zarNahLoAPygAohwz5czaCvXbDx2KdCxoAG7QKDagsqAAXPaOzq7umloWVlGyANys7Nx8AsKiElIyGj7QAGZo-swqOvqS0nIKymqguMVlFVrpTAK0UbWFreUsSi2ubSzVzQMVndAC9L0FSEWjg5WwuAC29METAIzprCD5dculq0rrW8GgAD6TK+2U1CNnFaxdoBgLJ1NDl9shO4vMbMCbA1agI7BFB8d6zUDMb79B5-TYA273V7jPSgXasIA)
* [When `strictNullCheck` is disabled](https://www.typescriptlang.org/play?strictNullChecks=false#code/PTAEHUAsFMDtQM4BcBOBLAxkgcgVwDb4DCMGA1qGgqHAIYBG+0AJgFDQAeADgPYpKgkATy7RQAZS740SACojoCADyyANKACqAPlABeTTQ5I4zarNahLoAPygAohwz5czaCvXbDx2KdCxoAG7QKDagsqAAXPaOzq7umloWVlGyANys7Nx8AsKiElIyGj7QAGZo-swqOvqS0nIKymqguMVlFVrpTAK0UbWFreUsSi2ubSzVzQMVndAC9L0FSEWjg5WwuAC29METAIzprCD5dculq0rrW8GgAD6TK+2U1CNnFaxdoBgLJ1NDl9shO4vMbMCbA1agI4BWjSZipQSQHi4ADmkARYlyYh4JVA0PQDCYoAABhgiU8aNDnLRjMxQLRqET-sEiepwRVyfSEGhkbACWIAO4weBE5DoLB4QgkaDkMlUUDMKh8tgfZjffoPP6bAG3e6vcZ6UC7VhAA)

The rest of changes are necessary changes so that type system works properly.