### PR TITLE
Tree Shakable package

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,11 +521,11 @@ Note that `Buffer.from()` for `JSON.stringify()` is necessary to emulate I/O whe
 
 The NPM package distributed in npmjs.com includes both ES2015+ and ES5 files:
 
-* `dist/` is compiled into ES2015+
-* `dist.es5+umd/` is compiled into ES5 and bundled to singile file
+* `dist/` is compiled into ES2015+, provided for NodeJS v10 or later
+* `dist.es5+umd/` is compiled into ES5 with UMD-style single file
   * `dist.es5+umd/msgpack.min.js` - the default, minified file (UMD)
   * `dist.es5+umd/msgpack.js` - an optional, non-minified file (UMD)
-* `dist.es5+esm/` is compiled into ES5 and placed as ES modules
+* `dist.es5+esm/` is compiled into ES5 and placed as ES modules, provided for webpack-like bundlers, not NodeJS
 
 If you use NodeJS and/or webpack, their module resolvers use the suitable one automatically.
 

--- a/example/webpack-example/.gitignore
+++ b/example/webpack-example/.gitignore
@@ -1,0 +1,1 @@
+package-lock.json

--- a/example/webpack-example/README.md
+++ b/example/webpack-example/README.md
@@ -1,0 +1,11 @@
+# Webpack Example for @msgpack/msgpack
+
+This example demonstrates tree-shaking with webpack.
+
+## Usage
+
+```shell
+npm install
+npx webpack
+ls -lh dist/
+```

--- a/example/webpack-example/index.ts
+++ b/example/webpack-example/index.ts
@@ -1,0 +1,4 @@
+import { encode } from "@msgpack/msgpack";
+
+console.log(encode(null));
+

--- a/example/webpack-example/package.json
+++ b/example/webpack-example/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "webpack-example",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@msgpack/msgpack": "../../"
+  },
+  "devDependencies": {
+    "lodash": "^4.17.20",
+    "ts-loader": "^8.0.4",
+    "ts-node": "^9.0.0",
+    "typescript": "^4.0.3",
+    "webpack": "^4.44.2",
+    "webpack-cli": "^3.3.12"
+  }
+}

--- a/example/webpack-example/tsconfig.json
+++ b/example/webpack-example/tsconfig.json
@@ -1,0 +1,71 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Basic Options */
+    // "incremental": true,                   /* Enable incremental compilation */
+    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "module": "es2020",                       /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    "paths": {
+      "@msgpack/msgpack": ["../../"]
+    },                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
+    /* Advanced Options */
+    "skipLibCheck": true,                     /* Skip type checking of declaration files. */
+    "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
+  }
+}

--- a/example/webpack-example/webpack.config.ts
+++ b/example/webpack-example/webpack.config.ts
@@ -1,0 +1,61 @@
+const path = require("path");
+const webpack = require("webpack");
+const _  = require("lodash");
+
+const config = {
+  mode: "production",
+
+  entry: "./index.ts",
+  output: {
+    path: path.resolve(__dirname, "dist"),
+    filename: undefined, // will be set later
+  },
+  resolve: {
+    extensions: [".ts", ".tsx", ".mjs", ".js", ".json", ".wasm"],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        loader: "ts-loader",
+        options: {
+          configFile: "tsconfig.json",
+        },
+      },
+    ],
+  },
+
+  plugins: [
+    new webpack.DefinePlugin({
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      "process.env.TEXT_ENCODING": "undefined",
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      "process.env.TEXT_DECODER": "undefined",
+    }),
+  ],
+
+  optimization: {
+    noEmitOnErrors: true,
+    minimize: false,
+  },
+
+  // We don't need NodeJS stuff on browsers!
+  // https://webpack.js.org/configuration/node/
+  node: false,
+
+  devtool: "source-map",
+};
+
+module.exports = [
+  ((config) => {
+    config.output.filename = "bundle.min.js";
+    config.optimization.minimize = true;
+    return config;
+  })(_.cloneDeep(config)),
+
+  ((config) => {
+    config.output.filename = "bundle.js";
+    config.optimization.minimize = false;
+    return config;
+  })(_.cloneDeep(config)),
+];

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "author": "The MessagePack community",
   "license": "ISC",
   "main": "./dist/index.js",
-  "browser": "./dist.es5+umd/msgpack.min.js",
   "module": "./dist.es5+esm/index.js",
+  "cdn": "./dist.es5+umd/msgpack.min.js",
+  "unpkg": "./dist.es5+umd/msgpack.min.js",
   "types": "./dist/index.d.ts",
   "sideEffects": false,
   "scripts": {


### PR DESCRIPTION
Webpack uses `browser` field in package.json as first, so it should be removed for ESM-based tree shaking.

https://webpack.js.org/configuration/resolve/