### PR TITLE
introduce decodeMulti()

### DIFF
--- a/src/Decoder.ts
+++ b/src/Decoder.ts
@@ -125,6 +125,15 @@ export class Decoder<ContextType> {
     return object;
   }
 
+  public *decodeMulti(buffer: ArrayLike<number> | BufferSource): Generator<unknown, void, unknown> {
+    this.reinitializeState();
+    this.setBuffer(buffer);
+
+    while (this.hasRemaining()) {
+      yield this.doDecodeSync();
+    }
+  }
+
   public async decodeAsync(stream: AsyncIterable<ArrayLike<number> | BufferSource>): Promise<unknown> {
     let decoded = false;
     let object: unknown;

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -38,9 +38,10 @@ export type DecodeOptions<ContextType = undefined> = Readonly<
 export const defaultDecodeOptions: DecodeOptions = {};
 
 /**
- * It decodes a MessagePack-encoded buffer.
+ * It decodes a single MessagePack object in a buffer.
  *
- * This is a synchronous decoding function. See other variants for asynchronous decoding: `decodeAsync()`, `decodeStream()`, `decodeArrayStream()`.
+ * This is a synchronous decoding function.
+ * See other variants for asynchronous decoding: {@link decodeAsync()}, {@link decodeStream()}, or {@link decodeArrayStream()}.
  */
 export function decode<ContextType = undefined>(
   buffer: ArrayLike<number> | BufferSource,
@@ -56,4 +57,24 @@ export function decode<ContextType = undefined>(
     options.maxExtLength,
   );
   return decoder.decode(buffer);
+}
+
+/**
+ * It decodes multiple MessagePack objects in a buffer.
+ * This is corresponding to {@link decodeMultiStream()}.
+ */
+export function decodeMulti<ContextType = undefined>(
+  buffer: ArrayLike<number> | BufferSource,
+  options: DecodeOptions<SplitUndefined<ContextType>> = defaultDecodeOptions as any,
+): Generator<unknown, void, unknown> {
+  const decoder = new Decoder(
+    options.extensionCodec,
+    (options as typeof options & { context: any }).context,
+    options.maxStrLength,
+    options.maxBinLength,
+    options.maxArrayLength,
+    options.maxMapLength,
+    options.maxExtLength,
+  );
+  return decoder.decodeMulti(buffer);
 }

--- a/src/decodeAsync.ts
+++ b/src/decodeAsync.ts
@@ -42,7 +42,7 @@ export function decodeArrayStream<ContextType>(
   return decoder.decodeArrayStream(stream);
 }
 
-export function decodeStream<ContextType>(
+export function decodeMultiStream<ContextType>(
   streamLike: ReadableStreamLike<ArrayLike<number> | BufferSource>,
   options: DecodeOptions<SplitUndefined<ContextType>> = defaultDecodeOptions as any,
 ) {
@@ -59,4 +59,14 @@ export function decodeStream<ContextType>(
   );
 
   return decoder.decodeStream(stream);
+}
+
+/**
+ * @deprecated Use {@link decodeMultiStream()} instead.
+ */
+export function decodeStream<ContextType>(
+  streamLike: ReadableStreamLike<ArrayLike<number> | BufferSource>,
+  options: DecodeOptions<SplitUndefined<ContextType>> = defaultDecodeOptions as any,
+) {
+  return decodeMultiStream(streamLike, options);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,13 +5,13 @@ export { encode };
 import type { EncodeOptions } from "./encode";
 export type { EncodeOptions };
 
-import { decode } from "./decode";
-export { decode };
+import { decode, decodeMulti } from "./decode";
+export { decode, decodeMulti };
 import type { DecodeOptions } from "./decode";
 export { DecodeOptions };
 
-import { decodeAsync, decodeArrayStream, decodeStream } from "./decodeAsync";
-export { decodeAsync, decodeArrayStream, decodeStream };
+import { decodeAsync, decodeArrayStream, decodeMultiStream, decodeStream } from "./decodeAsync";
+export { decodeAsync, decodeArrayStream, decodeMultiStream, decodeStream };
 
 import { Decoder } from "./Decoder";
 export { Decoder };

--- a/test/decodeMulti.test.ts
+++ b/test/decodeMulti.test.ts
@@ -1,0 +1,30 @@
+import assert from "assert";
+import { encode, decodeMulti } from "@msgpack/msgpack";
+
+describe("decodeMulti", () => {
+  it("decodes multiple objects in a single binary", () => {
+    const items = [
+      "foo",
+      10,
+      {
+        name: "bar",
+      },
+      [1, 2, 3],
+    ];
+
+    const encodedItems = items.map((item) => encode(item));
+    const encoded = new Uint8Array(encodedItems.reduce((p, c) => p + c.byteLength, 0));
+    let offset = 0;
+    for (const encodedItem of encodedItems) {
+      encoded.set(encodedItem, offset);
+      offset += encodedItem.byteLength;
+    }
+
+    const result: Array<unknown> = [];
+
+    for (const item of decodeMulti(encoded)) {
+      result.push(item);
+    }
+
+    assert.deepStrictEqual(result, items);
+  });});

--- a/test/decodeMultiStream.test.ts
+++ b/test/decodeMultiStream.test.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import { encode, decodeStream } from "@msgpack/msgpack";
+import { encode, decodeMultiStream } from "@msgpack/msgpack";
 
 describe("decodeStream", () => {
   it("decodes stream", async () => {
@@ -20,14 +20,14 @@ describe("decodeStream", () => {
 
     const result: Array<unknown> = [];
 
-    for await (const item of decodeStream(createStream())) {
+    for await (const item of decodeMultiStream(createStream())) {
       result.push(item);
     }
 
     assert.deepStrictEqual(result, items);
   });
 
-  it("decodes stream with a single binary", async () => {
+  it("decodes multiple objects in a single binary stream", async () => {
     const items = [
       "foo",
       10,
@@ -51,7 +51,7 @@ describe("decodeStream", () => {
 
     const result: Array<unknown> = [];
 
-    for await (const item of decodeStream(createStream())) {
+    for await (const item of decodeMultiStream(createStream())) {
       result.push(item);
     }
 


### PR DESCRIPTION
* introduce `decodeMulti()` to resolve #152
* introduce `decodeMultiStream()`, which is a new name for `decodeStream()`
* deprecate `decodeStream()` in favor of `decodeMultiStream()`

close #152