### PR TITLE
reject __proto__ since it could break the object

### DIFF
--- a/src/Decoder.ts
+++ b/src/Decoder.ts
@@ -64,7 +64,7 @@ export class DecodeError extends Error {
   constructor(message: string) {
     super(message);
 
-    Object.defineProperty(this, 'name', {
+    Object.defineProperty(this, "name", {
       configurable: true,
       enumerable: false,
       value: this.constructor.name,
@@ -413,6 +413,9 @@ export class Decoder<ContextType> {
           if (!isValidMapKeyType(object)) {
             throw new DecodeError("The type of key must be string or number but " + typeof object);
           }
+          if (object === "__proto__") {
+            throw new DecodeError("The key __proto__ is not allowed");
+          }
 
           state.key = object;
           state.type = State.MAP_VALUE;
@@ -498,7 +501,9 @@ export class Decoder<ContextType> {
 
   private decodeUtf8String(byteLength: number, headerOffset: number): string {
     if (byteLength > this.maxStrLength) {
-      throw new DecodeError(`Max length exceeded: UTF-8 byte length (${byteLength}) > maxStrLength (${this.maxStrLength})`);
+      throw new DecodeError(
+        `Max length exceeded: UTF-8 byte length (${byteLength}) > maxStrLength (${this.maxStrLength})`,
+      );
     }
 
     if (this.bytes.byteLength < this.pos + headerOffset + byteLength) {

--- a/src/Decoder.ts
+++ b/src/Decoder.ts
@@ -64,10 +64,14 @@ export class DecodeError extends Error {
   constructor(message: string) {
     super(message);
 
+    // fix the prototype chain in a cross-platform way
+    const proto = Object.create(DecodeError.prototype);
+    Object.setPrototypeOf(this, proto);
+
     Object.defineProperty(this, "name", {
       configurable: true,
       enumerable: false,
-      value: this.constructor.name,
+      value: DecodeError.name,
     });
   }
 }

--- a/test/prototype-pollution.test.ts
+++ b/test/prototype-pollution.test.ts
@@ -1,0 +1,22 @@
+import { throws } from "assert";
+import { encode, decode, DecodeError } from "@msgpack/msgpack";
+
+describe("prototype pollution", () => {
+  context("__proto__ exists as a map key", () => {
+    it("raises DecodeError in decoding", () => {
+      const o = {
+        foo: "bar",
+      };
+      // override __proto__ as an enumerable property
+      Object.defineProperty(o, "__proto__", {
+        value: new Date(0),
+        enumerable: true,
+      });
+      const encoded = encode(o);
+
+      throws(() => {
+        decode(encoded);
+      }, DecodeError);
+    });
+  });
+});


### PR DESCRIPTION
Injecting `__proto__` is a kind of the prototype pollution, although it's difficult to exploit. 