### PR TITLE
[CI] set security-events: write for CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,6 +13,9 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
 
+    permissions:
+      security-events: write
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2


### PR DESCRIPTION
This is required when "Workflow permissions" is set to "Read repository contents permission":

<img width="766" alt="Screen Shot 2022-03-19 at 10 25 58" src="https://user-images.githubusercontent.com/101800/159101464-c0c6c905-7e2e-41b7-b980-69453ec18b51.png">

As its README describes: https://github.com/github/codeql-action#usage