### PR TITLE
fix #212; Let Encoder#encode() return a copy of the internal buffer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   nodejs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version:
@@ -33,7 +33,7 @@ jobs:
     - run: codecov -f coverage/*.json
 
   browser:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         browser: [ChromeHeadless, FirefoxHeadless]

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/setup-node@v2
       with:
         cache: npm
-        node-version: "16"
+        node-version: "18"
 
     - run: npm ci
     - run: npm run test:fuzz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # This is the revision history of @msgpack/msgpack
 
+## NEXT
+
+* Let `Encoder#encode()` return a copy of the internal buffer, instead of the reference of the buffer (fix #212).
+  * Introducing `Encoder#encodeSharedRef()` to return the shared reference to the internal buffer.
+
 ## 2.7.2 2022/02/08
 
 https://github.com/msgpack/msgpack-javascript/compare/v2.7.1...v2.7.2

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:cover:purejs": "npx nyc --no-clean npm run test:purejs",
     "test:cover:te": "npx nyc --no-clean npm run test:te",
     "test:deno": "deno test test/deno_test.ts",
-    "test:fuzz": "npm exec -- jsfuzz@git+https://gitlab.com/gitlab-org/security-products/analyzers/fuzzers/jsfuzz.git --fuzzTime 60 --no-versifier test/decode.jsfuzz.js corpus",
+    "test:fuzz": "npm exec --yes -- jsfuzz@git+https://gitlab.com/gitlab-org/security-products/analyzers/fuzzers/jsfuzz.git --fuzzTime 60 --no-versifier test/decode.jsfuzz.js corpus",
     "cover:clean": "rimraf .nyc_output coverage/",
     "cover:report": "npx nyc report --reporter=text-summary --reporter=html --reporter=json",
     "test:browser": "karma start --single-run",

--- a/src/Encoder.ts
+++ b/src/Encoder.ts
@@ -23,18 +23,28 @@ export class Encoder<ContextType = undefined> {
     private readonly forceIntegerToFloat = false,
   ) {}
 
-  private getUint8Array(): Uint8Array {
-    return this.bytes.subarray(0, this.pos);
-  }
-
   private reinitializeState() {
     this.pos = 0;
   }
 
+  /**
+   * This is almost equivalent to {@link Encoder#encode}, but it returns an reference of the encoder's internal buffer and thus much faster than {@link Encoder#encode}.
+   *
+   * @returns Encodes the object and returns a shared reference the encoder's internal buffer.
+   */
+  public encodeSharedRef(object: unknown): Uint8Array {
+    this.reinitializeState();
+    this.doEncode(object, 1);
+    return this.bytes.subarray(0, this.pos);
+  }
+
+  /**
+   * @returns Encodes the object and returns a copy of the encoder's internal buffer.
+   */
   public encode(object: unknown): Uint8Array {
     this.reinitializeState();
     this.doEncode(object, 1);
-    return this.getUint8Array();
+    return this.bytes.slice(0, this.pos);
   }
 
   private doEncode(object: unknown, depth: number): void {

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -77,5 +77,5 @@ export function encode<ContextType = undefined>(
     options.ignoreUndefined,
     options.forceIntegerToFloat,
   );
-  return encoder.encode(value);
+  return encoder.encodeSharedRef(value);
 }


### PR DESCRIPTION
This is an intentional behavior but I'll change it because it's confusing. 

See #212 and the added tests for details.