### PR TITLE
optional BigInt support: map BigInt to int64/uint64 when `useBigInt64` is set to true

### DIFF
--- a/src/decode.ts
+++ b/src/decode.ts
@@ -7,6 +7,15 @@ export type DecodeOptions<ContextType = undefined> = Readonly<
     extensionCodec: ExtensionCodecType<ContextType>;
 
     /**
+     * Decodes Int64 and Uint64 as bigint if it's set to true.
+     * Depends on ES2020's {@link DataView#getBigInt64} and
+     * {@link DataView#getBigUint64}.
+     *
+     * Defaults to false.
+     */
+    useBigInt64: boolean;
+
+    /**
      * Maximum string length.
      *
      * Defaults to 4_294_967_295 (UINT32_MAX).
@@ -58,6 +67,7 @@ export function decode<ContextType = undefined>(
   const decoder = new Decoder(
     options.extensionCodec,
     (options as typeof options & { context: any }).context,
+    options.useBigInt64,
     options.maxStrLength,
     options.maxBinLength,
     options.maxArrayLength,
@@ -81,6 +91,7 @@ export function decodeMulti<ContextType = undefined>(
   const decoder = new Decoder(
     options.extensionCodec,
     (options as typeof options & { context: any }).context,
+    options.useBigInt64,
     options.maxStrLength,
     options.maxBinLength,
     options.maxArrayLength,

--- a/src/decodeAsync.ts
+++ b/src/decodeAsync.ts
@@ -18,6 +18,7 @@ import type { SplitUndefined } from "./context";
   const decoder = new Decoder(
     options.extensionCodec,
     (options as typeof options & { context: any }).context,
+    options.useBigInt64,
     options.maxStrLength,
     options.maxBinLength,
     options.maxArrayLength,
@@ -40,6 +41,7 @@ import type { SplitUndefined } from "./context";
   const decoder = new Decoder(
     options.extensionCodec,
     (options as typeof options & { context: any }).context,
+    options.useBigInt64,
     options.maxStrLength,
     options.maxBinLength,
     options.maxArrayLength,
@@ -63,6 +65,7 @@ export function decodeMultiStream<ContextType>(
   const decoder = new Decoder(
     options.extensionCodec,
     (options as typeof options & { context: any }).context,
+    options.useBigInt64,
     options.maxStrLength,
     options.maxBinLength,
     options.maxArrayLength,

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -7,6 +7,16 @@ export type EncodeOptions<ContextType = undefined> = Partial<
     extensionCodec: ExtensionCodecType<ContextType>;
 
     /**
+     * Encodes bigint as Int64 or Uint64 if it's set to true.
+     * {@link forceIntegerToFloat} does not affect bigint.
+     * Depends on ES2020's {@link DataView#setBigInt64} and
+     * {@link DataView#setBigUint64}.
+     *
+     * Defaults to false.
+     */
+    useBigInt64: boolean;
+
+    /**
      * The maximum depth in nested objects and arrays.
      *
      * Defaults to 100.
@@ -70,6 +80,7 @@ export function encode<ContextType = undefined>(
   const encoder = new Encoder(
     options.extensionCodec,
     (options as typeof options & { context: any }).context,
+    options.useBigInt64,
     options.maxDepth,
     options.initialBufferSize,
     options.sortKeys,

--- a/test/bigint64.test.ts
+++ b/test/bigint64.test.ts
@@ -1,0 +1,38 @@
+import assert from "assert";
+import { encode, decode } from "../src";
+
+describe("useBigInt64: true", () => {
+  before(function () {
+    if (typeof BigInt === "undefined") {
+      this.skip();
+    }
+  });
+
+  it("encodes and decodes 0n", () => {
+    const value = BigInt(0);
+    const encoded = encode(value, { useBigInt64: true });
+    assert.deepStrictEqual(decode(encoded, { useBigInt64: true }), value);
+  });
+
+  it("encodes and decodes MAX_SAFE_INTEGER+1", () => {
+    const value = BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1);
+    const encoded = encode(value, { useBigInt64: true });
+    assert.deepStrictEqual(decode(encoded, { useBigInt64: true }), value);
+  });
+
+  it("encodes and decodes MIN_SAFE_INTEGER-1", () => {
+    const value = BigInt(Number.MIN_SAFE_INTEGER) - BigInt(1);
+    const encoded = encode(value, { useBigInt64: true });
+    assert.deepStrictEqual(decode(encoded, { useBigInt64: true }), value);
+  });
+
+  it("encodes and decodes values with numbers and bigints", () => {
+    const value = {
+      ints: [0, Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER],
+      nums: [Number.NaN, Math.PI, Math.E, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY],
+      bigints: [BigInt(0), BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1), BigInt(Number.MIN_SAFE_INTEGER) - BigInt(1)],
+    };
+    const encoded = encode(value, { useBigInt64: true });
+    assert.deepStrictEqual(decode(encoded, { useBigInt64: true }), value);
+  });
+});

--- a/test/codec-bigint.test.ts
+++ b/test/codec-bigint.test.ts
@@ -1,6 +1,9 @@
 import assert from "assert";
 import { encode, decode, ExtensionCodec, DecodeError } from "../src";
 
+// This test is provided for backward compatibility since this library now has
+// native bigint support with `useBigInt64: true` option.
+
 const extensionCodec = new ExtensionCodec();
 extensionCodec.register({
   type: 0,


### PR DESCRIPTION
This PR introduces a new option `useBigInt64: boolean`, which enables "bigint mode" in this library.

Unfortunately, the bigint-mode handles JavaScript numbers completely differently than non-bigint-mode. The following table describes the type mappings.

<table>
<tr><th></th><th>useBigInt64: true</th><th>useBigInt64: false</th></tr>
<tr><td>a JavaScript safe integer but larger than UINT32_MAX</td><td>msgpack float64</td><td>msgpack uint64</td></tr>
<tr><td>a JavaScript safe integer but smaller than INT32_MIN</td><td>msgpack float64</td><td>msgpack int64</td></tr>
<tr><td>a JavaScript bigint</td><td>msgpack int64/uint64</td><td>N/A or extension</td></tr>
</table>

