### PR TITLE
Added a missing dev dependency `msg-timestamp`

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "karma-webpack": "latest",
     "lodash": "latest",
     "mocha": "latest",
+    "msg-timestamp": "^1.0.1",
     "msgpack-test-js": "latest",
     "prettier": "latest",
     "rimraf": "latest",


### PR DESCRIPTION
This is required to run tests.