### PR TITLE
feat: Expand bigint support to have more configurability

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,8 @@ import { decode, decodeMulti } from "./decode";
 export { decode, decodeMulti };
 import type { DecodeOptions } from "./decode";
 export type { DecodeOptions };
+import { IntMode } from './utils/int';
+export { IntMode };
 
 import { decodeAsync, decodeArrayStream, decodeMultiStream, decodeStream } from "./decodeAsync";
 export { decodeAsync, decodeArrayStream, decodeMultiStream, decodeStream };

--- a/src/timestamp.ts
+++ b/src/timestamp.ts
@@ -1,6 +1,6 @@
 // https://github.com/msgpack/msgpack/blob/master/spec.md#timestamp-extension-type
 import { DecodeError } from "./DecodeError";
-import { getInt64, setInt64 } from "./utils/int";
+import { IntMode, getInt64, setInt64 } from "./utils/int";
 
 export const EXT_TIMESTAMP = -1;
 
@@ -87,7 +87,7 @@ export function decodeTimestampToTimeSpec(data: Uint8Array): TimeSpec {
     case 12: {
       // timestamp 96 = { nsec32 (unsigned), sec64 (signed) }
 
-      const sec = getInt64(view, 4);
+      const sec = getInt64(view, 4, IntMode.UNSAFE_NUMBER);
       const nsec = view.getUint32(0);
       return { sec, nsec };
     }

--- a/src/utils/int.ts
+++ b/src/utils/int.ts
@@ -1,5 +1,30 @@
 // Integer Utility
 
+/**
+ * An enum of different options for decoding integers.
+ */
+export enum IntMode {
+  /**
+   * Always returns the value as a number. Be aware that there will be a loss of precision if the
+   * value is outside the range of Number.MIN_SAFE_INTEGER to Number.MAX_SAFE_INTEGER.
+   */
+  UNSAFE_NUMBER,
+  /**
+   * Always returns the value as a number, but throws an error if the value is outside of the range
+   * of Number.MIN_SAFE_INTEGER to Number.MAX_SAFE_INTEGER.
+   */
+  SAFE_NUMBER,
+  /**
+   * Returns all values inside the range of Number.MIN_SAFE_INTEGER to Number.MAX_SAFE_INTEGER as
+   * numbers and all values outside that range as bigints.
+   */
+  MIXED,
+  /**
+   * Always returns the value as a bigint, even if it is small enough to safely fit in a number.
+   */
+  BIGINT,
+}
+
 export const UINT32_MAX = 0xffff_ffff;
 
 // DataView extension to handle int64 / uint64,
@@ -19,14 +44,71 @@ export function setInt64(view: DataView, offset: number, value: number): void {
   view.setUint32(offset + 4, low);
 }
 
-export function getInt64(view: DataView, offset: number): number {
-  const high = view.getInt32(offset);
-  const low = view.getUint32(offset + 4);
-  return high * 0x1_0000_0000 + low;
+export function getInt64(view: DataView, offset: number, mode: IntMode.UNSAFE_NUMBER | IntMode.SAFE_NUMBER): number
+export function getInt64(view: DataView, offset: number, mode: IntMode.BIGINT): bigint
+export function getInt64(view: DataView, offset: number, mode: IntMode): number | bigint
+export function getInt64(view: DataView, offset: number, mode: IntMode): number | bigint {
+  if (mode === IntMode.UNSAFE_NUMBER || mode === IntMode.SAFE_NUMBER) {
+    // for compatibility, don't use view.getBigInt64 if the user hasn't told us to use BigInts
+    const high = view.getInt32(offset);
+    const low = view.getUint32(offset + 4);
+
+    if (mode === IntMode.SAFE_NUMBER && (
+      high < Math.floor(Number.MIN_SAFE_INTEGER / 0x1_0000_0000) ||
+      (high === Math.floor(Number.MIN_SAFE_INTEGER / 0x1_0000_0000) && low === 0) ||
+      high > (Number.MAX_SAFE_INTEGER - low) / 0x1_0000_0000
+    )) {
+      const hexValue = `${high < 0 ? "-" : ""}0x${Math.abs(high).toString(16)}${low.toString(16).padStart(8, "0")}`;
+      throw new Error(`Mode is IntMode.SAFE_NUMBER and value is not a safe integer: ${hexValue}`);
+    }
+
+    return high * 0x1_0000_0000 + low;
+  }
+
+  const value = view.getBigInt64(offset);
+
+  if (mode === IntMode.MIXED && value >= Number.MIN_SAFE_INTEGER && value <= Number.MAX_SAFE_INTEGER) {
+    return Number(value);
+  }
+
+  return value;
 }
 
-export function getUint64(view: DataView, offset: number): number {
-  const high = view.getUint32(offset);
-  const low = view.getUint32(offset + 4);
-  return high * 0x1_0000_0000 + low;
+export function getUint64(view: DataView, offset: number, mode: IntMode.UNSAFE_NUMBER | IntMode.SAFE_NUMBER): number
+export function getUint64(view: DataView, offset: number, mode: IntMode.BIGINT): bigint
+export function getUint64(view: DataView, offset: number, mode: IntMode): number | bigint
+export function getUint64(view: DataView, offset: number, mode: IntMode): number | bigint {
+  if (mode === IntMode.UNSAFE_NUMBER || mode === IntMode.SAFE_NUMBER) {
+    // for compatibility, don't use view.getBigUint64 if the user hasn't told us to use BigInts
+    const high = view.getUint32(offset);
+    const low = view.getUint32(offset + 4);
+
+    if (mode === IntMode.SAFE_NUMBER && high > (Number.MAX_SAFE_INTEGER - low) / 0x1_0000_0000) {
+      const hexValue = `0x${high.toString(16)}${low.toString(16).padStart(8, "0")}`;
+      throw new Error(`Mode is IntMode.SAFE_NUMBER and value is not a safe integer: ${hexValue}`);
+    }
+
+    return high * 0x1_0000_0000 + low;
+  }
+
+  const value = view.getBigUint64(offset);
+
+  if (mode === IntMode.MIXED && value <= Number.MAX_SAFE_INTEGER) {
+    return Number(value);
+  }
+
+  return value;
+}
+
+/**
+ * Convert a safe integer Number (i.e. in the range Number.MIN_SAFE_INTEGER to Number.MAX_SAFE_INTEGER)
+ * with respect to the given IntMode. For all modes except IntMode.BIGINT, this returns the original
+ * Number unmodified.
+ */
+export function convertSafeIntegerToMode(value: number, mode: IntMode): number | bigint {
+  if (mode === IntMode.BIGINT) {
+    return BigInt(value);
+  }
+
+  return value;
 }

--- a/test/bigint64.test.ts
+++ b/test/bigint64.test.ts
@@ -10,19 +10,19 @@ describe("useBigInt64: true", () => {
 
   it("encodes and decodes 0n", () => {
     const value = BigInt(0);
-    const encoded = encode(value, { useBigInt64: true });
+    const encoded = encode(value);
     assert.deepStrictEqual(decode(encoded, { useBigInt64: true }), value);
   });
 
   it("encodes and decodes MAX_SAFE_INTEGER+1", () => {
     const value = BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1);
-    const encoded = encode(value, { useBigInt64: true });
+    const encoded = encode(value);
     assert.deepStrictEqual(decode(encoded, { useBigInt64: true }), value);
   });
 
   it("encodes and decodes MIN_SAFE_INTEGER-1", () => {
     const value = BigInt(Number.MIN_SAFE_INTEGER) - BigInt(1);
-    const encoded = encode(value, { useBigInt64: true });
+    const encoded = encode(value);
     assert.deepStrictEqual(decode(encoded, { useBigInt64: true }), value);
   });
 
@@ -32,7 +32,7 @@ describe("useBigInt64: true", () => {
       nums: [Number.NaN, Math.PI, Math.E, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY],
       bigints: [BigInt(0), BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1), BigInt(Number.MIN_SAFE_INTEGER) - BigInt(1)],
     };
-    const encoded = encode(value, { useBigInt64: true });
+    const encoded = encode(value);
     assert.deepStrictEqual(decode(encoded, { useBigInt64: true }), value);
   });
 });

--- a/test/codec-bigint.test.ts
+++ b/test/codec-bigint.test.ts
@@ -1,5 +1,6 @@
 import assert from "assert";
 import { encode, decode, ExtensionCodec, DecodeError } from "../src";
+import { IntMode, getInt64, getUint64 } from "../src/utils/int";
 
 // There's a built-in `useBigInt64: true` option, but a custom codec might be
 // better if you'd like to encode bigint to reduce the size of binaries.
@@ -29,11 +30,229 @@ extensionCodec.register({
   },
 });
 
+interface TestCase {
+  input: bigint,
+  expected: Map<IntMode, number | bigint | "error">,
+}
+
+// declared as a function to delay referencing the BigInt constructor
+function BIGINTSPECS(): Record<string, TestCase> {
+  return {
+    ZERO: {
+      input: BigInt(0),
+      expected: new Map<IntMode, number | bigint>([
+        [IntMode.UNSAFE_NUMBER, 0],
+        [IntMode.SAFE_NUMBER, 0],
+        [IntMode.MIXED, 0],
+        [IntMode.BIGINT, BigInt(0)],
+      ])
+    },
+    ONE: {
+      input: BigInt(1),
+      expected: new Map<IntMode, number | bigint>([
+        [IntMode.UNSAFE_NUMBER, 1],
+        [IntMode.SAFE_NUMBER, 1],
+        [IntMode.MIXED, 1],
+        [IntMode.BIGINT, BigInt(1)],
+      ])
+    },
+    MINUS_ONE: {
+      input: BigInt(-1),
+      expected: new Map<IntMode, number | bigint>([
+        [IntMode.UNSAFE_NUMBER, -1],
+        [IntMode.SAFE_NUMBER, -1],
+        [IntMode.MIXED, -1],
+        [IntMode.BIGINT, BigInt(-1)],
+      ])
+    },
+    X_FF: {
+      input: BigInt(0xff),
+      expected: new Map<IntMode, number | bigint>([
+        [IntMode.UNSAFE_NUMBER, 0xff],
+        [IntMode.SAFE_NUMBER, 0xff],
+        [IntMode.MIXED, 0xff],
+        [IntMode.BIGINT, BigInt(0xff)],
+      ])
+    },
+    MINUS_X_FF: {
+      input: BigInt(-0xff),
+      expected: new Map<IntMode, number | bigint>([
+        [IntMode.UNSAFE_NUMBER, -0xff],
+        [IntMode.SAFE_NUMBER, -0xff],
+        [IntMode.MIXED, -0xff],
+        [IntMode.BIGINT, BigInt(-0xff)],
+      ])
+    },
+    INT32_MAX: {
+      input: BigInt(0x7fffffff),
+      expected: new Map<IntMode, number | bigint>([
+        [IntMode.UNSAFE_NUMBER, 0x7fffffff],
+        [IntMode.SAFE_NUMBER, 0x7fffffff],
+        [IntMode.MIXED, 0x7fffffff],
+        [IntMode.BIGINT, BigInt(0x7fffffff)],
+      ])
+    },
+    INT32_MIN: {
+      input: BigInt(-0x7fffffff - 1),
+      expected: new Map<IntMode, number | bigint>([
+        [IntMode.UNSAFE_NUMBER, -0x7fffffff - 1],
+        [IntMode.SAFE_NUMBER, -0x7fffffff - 1],
+        [IntMode.MIXED, -0x7fffffff - 1],
+        [IntMode.BIGINT, BigInt(-0x7fffffff - 1)],
+      ])
+    },
+    MAX_SAFE_INTEGER: {
+      input: BigInt(Number.MAX_SAFE_INTEGER),
+      expected: new Map<IntMode, number | bigint>([
+        [IntMode.UNSAFE_NUMBER, Number.MAX_SAFE_INTEGER],
+        [IntMode.SAFE_NUMBER, Number.MAX_SAFE_INTEGER],
+        [IntMode.MIXED, Number.MAX_SAFE_INTEGER],
+        [IntMode.BIGINT, BigInt(Number.MAX_SAFE_INTEGER)],
+      ])
+    },
+    MAX_SAFE_INTEGER_PLUS_ONE: {
+      input: BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1),
+      expected: new Map<IntMode, number | bigint | "error">([
+        // exclude IntMode.UNSAFE_NUMBER, behavior will not be exact
+        [IntMode.SAFE_NUMBER, "error"],
+        [IntMode.MIXED, BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1)],
+        [IntMode.BIGINT, BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1)],
+      ])
+    },
+    MIN_SAFE_INTEGER: {
+      input: BigInt(Number.MIN_SAFE_INTEGER),
+      expected: new Map<IntMode, number | bigint>([
+        [IntMode.UNSAFE_NUMBER, Number.MIN_SAFE_INTEGER],
+        [IntMode.SAFE_NUMBER, Number.MIN_SAFE_INTEGER],
+        [IntMode.MIXED, Number.MIN_SAFE_INTEGER],
+        [IntMode.BIGINT, BigInt(Number.MIN_SAFE_INTEGER)],
+      ])
+    },
+    MIN_SAFE_INTEGER_MINUS_ONE: {
+      input: BigInt(Number.MIN_SAFE_INTEGER) - BigInt(1),
+      expected: new Map<IntMode, number | bigint | "error">([
+        // exclude IntMode.UNSAFE_NUMBER, behavior will not be exact
+        [IntMode.SAFE_NUMBER, "error"],
+        [IntMode.MIXED, BigInt(Number.MIN_SAFE_INTEGER) - BigInt(1)],
+        [IntMode.BIGINT, BigInt(Number.MIN_SAFE_INTEGER) - BigInt(1)],
+      ]),
+    },
+    INT64_MAX: {
+      input: BigInt("0x7fffffffffffffff"),
+      expected: new Map<IntMode, number | bigint | "error">([
+        // exclude IntMode.UNSAFE_NUMBER, behavior will not be exact
+        [IntMode.SAFE_NUMBER, "error"],
+        [IntMode.MIXED, BigInt("0x7fffffffffffffff")],
+        [IntMode.BIGINT, BigInt("0x7fffffffffffffff")],
+      ])
+    },
+    INT64_MIN: {
+      input: BigInt(-1) * BigInt("0x8000000000000000"),
+      expected: new Map<IntMode, number | bigint | "error">([
+        // exclude IntMode.UNSAFE_NUMBER, behavior will not be exact
+        [IntMode.SAFE_NUMBER, "error"],
+        [IntMode.MIXED, BigInt(-1) * BigInt("0x8000000000000000")],
+        [IntMode.BIGINT, BigInt(-1) * BigInt("0x8000000000000000")],
+      ]),
+    },
+  }
+}
+
+// declared as a function to delay referencing the BigInt constructor
+function BIGUINTSPECS(): Record<string, TestCase> {
+  return {
+    ZERO: {
+      input: BigInt(0),
+      expected: new Map<IntMode, number | bigint>([
+        [IntMode.UNSAFE_NUMBER, 0],
+        [IntMode.SAFE_NUMBER, 0],
+        [IntMode.MIXED, 0],
+        [IntMode.BIGINT, BigInt(0)],
+      ])
+    },
+    ONE: {
+      input: BigInt(1),
+      expected: new Map<IntMode, number | bigint>([
+        [IntMode.UNSAFE_NUMBER, 1],
+        [IntMode.SAFE_NUMBER, 1],
+        [IntMode.MIXED, 1],
+        [IntMode.BIGINT, BigInt(1)],
+      ])
+    },
+    X_FF: {
+      input: BigInt(0xff),
+      expected: new Map<IntMode, number | bigint>([
+        [IntMode.UNSAFE_NUMBER, 0xff],
+        [IntMode.SAFE_NUMBER, 0xff],
+        [IntMode.MIXED, 0xff],
+        [IntMode.BIGINT, BigInt(0xff)],
+      ])
+    },
+    UINT32_MAX: {
+      input: BigInt(0xffffffff),
+      expected: new Map<IntMode, number | bigint>([
+        [IntMode.UNSAFE_NUMBER, 0xffffffff],
+        [IntMode.SAFE_NUMBER, 0xffffffff],
+        [IntMode.MIXED, 0xffffffff],
+        [IntMode.BIGINT, BigInt(0xffffffff)],
+      ])
+    },
+    MAX_SAFE_INTEGER: {
+      input: BigInt(Number.MAX_SAFE_INTEGER),
+      expected: new Map<IntMode, number | bigint>([
+        [IntMode.UNSAFE_NUMBER, Number.MAX_SAFE_INTEGER],
+        [IntMode.SAFE_NUMBER, Number.MAX_SAFE_INTEGER],
+        [IntMode.MIXED, Number.MAX_SAFE_INTEGER],
+        [IntMode.BIGINT, BigInt(Number.MAX_SAFE_INTEGER)],
+      ])
+    },
+    MAX_SAFE_INTEGER_PLUS_ONE: {
+      input: BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1),
+      expected: new Map<IntMode, number | bigint | "error">([
+        // exclude IntMode.UNSAFE_NUMBER, behavior will not be exact
+        [IntMode.SAFE_NUMBER, "error"],
+        [IntMode.MIXED, BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1)],
+        [IntMode.BIGINT, BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1)],
+      ])
+    },
+    UINT64_MAX: {
+      input: BigInt("0xffffffffffffffff"),
+      expected: new Map<IntMode, number | bigint | "error">([
+        // exclude IntMode.UNSAFE_NUMBER, behavior will not be exact
+        [IntMode.SAFE_NUMBER, "error"],
+        [IntMode.MIXED, BigInt("0xffffffffffffffff")],
+        [IntMode.BIGINT, BigInt("0xffffffffffffffff")],
+      ])
+    },
+  }
+}
+
+function abs(value: bigint): bigint {
+  if (value < 0) {
+    return BigInt(-1) * value;
+  }
+  return value;
+}
+
 describe("codec BigInt", () => {
-  it("encodes and decodes 0n", () => {
-    const value = BigInt(0);
-    const encoded = encode(value, { extensionCodec });
-    assert.deepStrictEqual(decode(encoded, { extensionCodec }), value);
+  context("extension", () => {
+    it("encodes and decodes 0n", () => {
+      const value = BigInt(0);
+      const encoded = encode(value, { extensionCodec });
+      assert.deepStrictEqual(decode(encoded, { extensionCodec }), value);
+    });
+  
+    it("encodes and decodes MAX_SAFE_INTEGER+1", () => {
+      const value = BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1);
+      const encoded = encode(value, { extensionCodec });
+      assert.deepStrictEqual(decode(encoded, { extensionCodec }), value);
+    });
+  
+    it("encodes and decodes MIN_SAFE_INTEGER-1", () => {
+      const value = BigInt(Number.MIN_SAFE_INTEGER) - BigInt(1);
+      const encoded = encode(value, { extensionCodec });
+      assert.deepStrictEqual(decode(encoded, { extensionCodec }), value);
+    });
   });
 
   it("encodes and decodes 100n", () => {
@@ -53,10 +272,47 @@ describe("codec BigInt", () => {
     const encoded = encode(value, { extensionCodec });
     assert.deepStrictEqual(decode(encoded, { extensionCodec }), value);
   });
+  context("native", () => {
+    context("int 64", () => {
+      const specs = BIGINTSPECS();
 
-  it("encodes and decodes MIN_SAFE_INTEGER-1", () => {
-    const value = BigInt(Number.MIN_SAFE_INTEGER) - BigInt(1);
-    const encoded = encode(value, { extensionCodec });
-    assert.deepStrictEqual(decode(encoded, { extensionCodec }), value);
+      for (const name of Object.keys(specs)) {
+        const testCase = specs[name]!;
+  
+        it(`sets and gets ${testCase.input} (${testCase.input < 0 ? "-" : ""}0x${abs(testCase.input).toString(16)})`, () => {
+          const b = new Uint8Array(8);
+          const view = new DataView(b.buffer);
+          view.setBigInt64(0, testCase.input);
+          for (const [mode, expected] of testCase.expected) {
+            if (expected === "error") {
+              assert.throws(() => getInt64(view, 0, mode), new RegExp(`Mode is IntMode\\.SAFE_NUMBER and value is not a safe integer: ${testCase.input < 0 ? "-" : ""}0x${abs(testCase.input).toString(16)}$`));
+              continue;
+            }
+            assert.deepStrictEqual(getInt64(view, 0, mode), expected);
+          }
+        });
+      }
+    });
+
+    context("uint 64", () => {
+      const specs = BIGUINTSPECS();
+
+      for (const name of Object.keys(specs)) {
+        const testCase = specs[name]!;
+  
+        it(`sets and gets ${testCase.input} (0x${testCase.input.toString(16)})`, () => {
+          const b = new Uint8Array(8);
+          const view = new DataView(b.buffer);
+          view.setBigUint64(0, testCase.input);
+          for (const [mode, expected] of testCase.expected) {
+            if (expected === "error") {
+              assert.throws(() => getUint64(view, 0, mode), new RegExp(`Mode is IntMode\\.SAFE_NUMBER and value is not a safe integer: 0x${testCase.input.toString(16)}$`));
+              continue;
+            }
+            assert.deepStrictEqual(getUint64(view, 0, mode), expected);
+          }
+        });
+      }
+    });
   });
 });

--- a/test/codec-int.test.ts
+++ b/test/codec-int.test.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import { setInt64, getInt64, getUint64, setUint64 } from "../src/utils/int";
+import { IntMode, setInt64, getInt64, getUint64, setUint64 } from "../src/utils/int";
 
 const INT64SPECS = {
   ZERO: 0,
@@ -22,7 +22,12 @@ describe("codec: int64 / uint64", () => {
         const b = new Uint8Array(8);
         const view = new DataView(b.buffer);
         setInt64(view, 0, value);
-        assert.deepStrictEqual(getInt64(view, 0), value);
+        assert.deepStrictEqual(getInt64(view, 0, IntMode.UNSAFE_NUMBER), value);
+        assert.deepStrictEqual(getInt64(view, 0, IntMode.SAFE_NUMBER), value);
+        if (typeof BigInt !== "undefined") {
+          assert.deepStrictEqual(getInt64(view, 0, IntMode.MIXED), value);
+          assert.deepStrictEqual(getInt64(view, 0, IntMode.BIGINT), BigInt(value));
+        }
       });
     }
   });
@@ -32,14 +37,24 @@ describe("codec: int64 / uint64", () => {
       const b = new Uint8Array(8);
       const view = new DataView(b.buffer);
       setUint64(view, 0, 0);
-      assert.deepStrictEqual(getUint64(view, 0), 0);
+      assert.deepStrictEqual(getUint64(view, 0, IntMode.UNSAFE_NUMBER), 0);
+      assert.deepStrictEqual(getUint64(view, 0, IntMode.SAFE_NUMBER), 0);
+      if (typeof BigInt !== "undefined") {
+        assert.deepStrictEqual(getUint64(view, 0, IntMode.MIXED), 0);
+        assert.deepStrictEqual(getUint64(view, 0, IntMode.BIGINT), BigInt(0));
+      }
     });
 
     it(`sets and gets MAX_SAFE_INTEGER`, () => {
       const b = new Uint8Array(8);
       const view = new DataView(b.buffer);
       setUint64(view, 0, Number.MAX_SAFE_INTEGER);
-      assert.deepStrictEqual(getUint64(view, 0), Number.MAX_SAFE_INTEGER);
+      assert.deepStrictEqual(getUint64(view, 0, IntMode.UNSAFE_NUMBER), Number.MAX_SAFE_INTEGER);
+      assert.deepStrictEqual(getUint64(view, 0, IntMode.SAFE_NUMBER), Number.MAX_SAFE_INTEGER);
+      if (typeof BigInt !== "undefined") {
+        assert.deepStrictEqual(getUint64(view, 0, IntMode.MIXED), Number.MAX_SAFE_INTEGER);
+        assert.deepStrictEqual(getUint64(view, 0, IntMode.BIGINT), BigInt(Number.MAX_SAFE_INTEGER));
+      }
     });
   });
 });

--- a/test/encode.test.ts
+++ b/test/encode.test.ts
@@ -28,6 +28,10 @@ describe("encode", () => {
   context("forceFloat", () => {
     it("encodes integers as integers without forceIntegerToFloat", () => {
       assert.deepStrictEqual(encode(3), Uint8Array.from([0x3]));
+
+      if (typeof BigInt !== "undefined") {
+        assert.deepStrictEqual(encode(BigInt(3)), Uint8Array.from([0x3]));
+      }
     });
 
     it("encodes integers as floating point when forceIntegerToFloat=true", () => {
@@ -35,6 +39,13 @@ describe("encode", () => {
         encode(3, { forceIntegerToFloat: true }),
         Uint8Array.from([0xcb, 0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
       );
+
+      if (typeof BigInt !== "undefined") {
+        assert.deepStrictEqual(
+          encode(BigInt(3), { forceIntegerToFloat: true }),
+          Uint8Array.from([0xcb, 0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
+        );
+      }
     });
 
     it("encodes integers as float32 when forceIntegerToFloat=true and forceFloat32=true", () => {
@@ -42,10 +53,21 @@ describe("encode", () => {
         encode(3, { forceIntegerToFloat: true, forceFloat32: true }),
         Uint8Array.from([0xca, 0x40, 0x40, 0x00, 0x00]),
       );
+
+      if (typeof BigInt !== "undefined") {
+        assert.deepStrictEqual(
+          encode(BigInt(3), { forceIntegerToFloat: true, forceFloat32: true }),
+          Uint8Array.from([0xca, 0x40, 0x40, 0x00, 0x00]),
+        );
+      }
     });
 
     it("encodes integers as integers when forceIntegerToFloat=false", () => {
       assert.deepStrictEqual(encode(3, { forceIntegerToFloat: false }), Uint8Array.from([0x3]));
+
+      if (typeof BigInt !== "undefined") {
+        assert.deepStrictEqual(encode(BigInt(3), { forceIntegerToFloat: false }), Uint8Array.from([0x3]));
+      }
     });
   });
 
@@ -70,5 +92,15 @@ describe("encode", () => {
     const buffer = encode([1, 2, 3]);
     const arrayBuffer = buffer.buffer.slice(buffer.byteOffset, buffer.byteLength);
     assert.deepStrictEqual(decode(arrayBuffer), decode(buffer));
+  });
+
+  context("Bigint that exceeds 64 bits", () => {
+    if (typeof BigInt !== "undefined") {
+      const MAX_UINT64_PLUS_ONE = BigInt("0x10000000000000000");
+      assert.throws(() => encode(MAX_UINT64_PLUS_ONE), /Bigint is too large for uint64: 18446744073709551616$/);
+
+      const MIN_INT64_MINUS_ONE = BigInt(-1) * BigInt("0x8000000000000001");
+      assert.throws(() => encode(MIN_INT64_MINUS_ONE), /Bigint is too small for int64: -9223372036854775809$/);
+    }
   });
 });


### PR DESCRIPTION
Took https://github.com/msgpack/msgpack-javascript/pull/211, rebased against latest `main`.

BigInt support had been added (in a very basic way) in msgpack library, so melding this in.

Work in progress: have a breaking test.