### PR TITLE
Allow the data alignment to support zero-copy decoding

### DIFF
--- a/benchmark/msgpack-benchmark.js
+++ b/benchmark/msgpack-benchmark.js
@@ -3,13 +3,65 @@
 "use strict";
 require("ts-node/register");
 const Benchmark = require("benchmark");
-const fs = require("fs");
-const msgpack = require("../src");
+
+const msgpackEncode = require("..").encode;
+const msgpackDecode = require("..").decode;
+const ExtensionCodec = require("..").ExtensionCodec;
+
+const float32ArrayExtensionCodec = new ExtensionCodec();
+float32ArrayExtensionCodec.register({
+  type: 0x01,
+  encode: (object) => {
+    if (object instanceof Float32Array) {
+      return new Uint8Array(object.buffer, object.byteOffset, object.byteLength);
+    }
+    return null;
+  },
+  decode: (data) => {
+    const copy = new Uint8Array(data.byteLength);
+    copy.set(data);
+    return new Float32Array(copy.buffer);
+  },
+});
+
+const float32ArrayZeroCopyExtensionCodec = new ExtensionCodec();
+float32ArrayZeroCopyExtensionCodec.register({
+  type: 0x01,
+  encode: (object) => {
+    if (object instanceof Float32Array) {
+      return (pos) => {
+        const bpe = Float32Array.BYTES_PER_ELEMENT;
+        const padding = 1 + ((bpe - ((pos + 1) % bpe)) % bpe);
+        const data = new Uint8Array(object.buffer);
+        const result = new Uint8Array(padding + data.length);
+        result[0] = padding;
+        result.set(data, padding);
+        return result;
+      };
+    }
+    return null;
+  },
+  decode: (data) => {
+    const padding = data[0];
+    const bpe = Float32Array.BYTES_PER_ELEMENT;
+    const offset = data.byteOffset + padding;
+    const length = data.byteLength - padding;
+    return new Float32Array(data.buffer, offset, length / bpe);
+  },
+});
 
 const implementations = {
   "@msgpack/msgpack": {
-    encode: require("..").encode,
-    decode: require("..").decode,
+    encode: msgpackEncode,
+    decode: msgpackDecode,
+  },
+  "@msgpack/msgpack (Float32Array extension)": {
+    encode: (data) => msgpackEncode(data, { extensionCodec: float32ArrayExtensionCodec }),
+    decode: (data) => msgpackDecode(data, { extensionCodec: float32ArrayExtensionCodec }),
+  },
+  "@msgpack/msgpack (Float32Array with zero-copy extension)": {
+    encode: (data) => msgpackEncode(data, { extensionCodec: float32ArrayZeroCopyExtensionCodec }),
+    decode: (data) => msgpackDecode(data, { extensionCodec: float32ArrayZeroCopyExtensionCodec }),
   },
   "msgpack-lite": {
     encode: require("msgpack-lite").encode,
@@ -21,28 +73,52 @@ const implementations = {
   },
 };
 
-// exactly the same as:
-// https://raw.githubusercontent.com/endel/msgpack-benchmark/master/sample-large.json
-const sampleFiles = ["./sample-large.json"];
+const samples = [
+  {
+    // exactly the same as:
+    // https://raw.githubusercontent.com/endel/msgpack-benchmark/master/sample-large.json
+    name: "./sample-large.json",
+    data: require("./sample-large.json"),
+  },
+  {
+    name: "Large array of numbers",
+    data: [
+      {
+        position: new Array(1e3).fill(1.14),
+      },
+    ],
+  },
+  {
+    name: "Large Float32Array",
+    data: [
+      {
+        position: new Float32Array(1e3).fill(1.14),
+      },
+    ],
+  },
+];
 
 function validate(name, data, encoded) {
-  if (JSON.stringify(data) !== JSON.stringify(implementations[name].decode(encoded))) {
-    throw new Error("Bad implementation: " + name);
-  }
+  return JSON.stringify(data) === JSON.stringify(implementations[name].decode(encoded));
 }
 
-for (const sampleFile of sampleFiles) {
-  const data = require(sampleFile);
+for (const sample of samples) {
+  const { name: sampleName, data } = sample;
   const encodeSuite = new Benchmark.Suite();
   const decodeSuite = new Benchmark.Suite();
 
   console.log("");
-  console.log("**" + sampleFile + ":** (" + JSON.stringify(data).length + " bytes in JSON)");
+  console.log("**" + sampleName + ":** (" + JSON.stringify(data).length + " bytes in JSON)");
   console.log("");
 
   for (const name of Object.keys(implementations)) {
     implementations[name].toDecode = implementations[name].encode(data);
-    validate(name, data, implementations[name].toDecode);
+    if (!validate(name, data, implementations[name].toDecode)) {
+      console.log("```");
+      console.log("Not supported by " + name);
+      console.log("```");
+      continue;
+    }
     encodeSuite.add("(encode) " + name, () => {
       implementations[name].encode(data);
     });
@@ -60,7 +136,7 @@ for (const sampleFile of sampleFiles) {
 
   console.log("");
 
-  decodeSuite.on("cycle", function(event) {
+  decodeSuite.on("cycle", (event) => {
     console.log(String(event.target));
   });
 

--- a/src/Encoder.ts
+++ b/src/Encoder.ts
@@ -396,6 +396,21 @@ export class Encoder<ContextType = undefined> {
   }
 
   private encodeExtension(ext: ExtData) {
+    if (typeof ext.data === "function") {
+      const data = ext.data(this.pos + 6);
+      const size = data.length;
+
+      if (size >= 0x100000000) {
+        throw new Error(`Too large extension object: ${size}`);
+      }
+
+      this.writeU8(0xc9);
+      this.writeU32(size);
+      this.writeI8(ext.type);
+      this.writeU8a(data);
+      return;
+    }
+
     const size = ext.data.length;
     if (size === 1) {
       // fixext 1

--- a/src/ExtData.ts
+++ b/src/ExtData.ts
@@ -3,12 +3,9 @@
  */
 export class ExtData {
   readonly type: number;
-  readonly data: Uint8Array;
+  readonly data: Uint8Array | ((pos: number) => Uint8Array);
 
-  constructor(
-    type: number,
-    data: Uint8Array,
-  ) {
+  constructor(type: number, data: Uint8Array | ((pos: number) => Uint8Array)) {
     this.type = type;
     this.data = data;
   }

--- a/src/ExtensionCodec.ts
+++ b/src/ExtensionCodec.ts
@@ -9,7 +9,10 @@ export type ExtensionDecoderType<ContextType> = (
   context: ContextType,
 ) => unknown;
 
-export type ExtensionEncoderType<ContextType> = (input: unknown, context: ContextType) => Uint8Array | null;
+export type ExtensionEncoderType<ContextType> = (
+  input: unknown,
+  context: ContextType,
+) => Uint8Array | ((dataPos: number) => Uint8Array) | null;
 
 // immutable interface to ExtensionCodec
 export type ExtensionCodecType<ContextType> = {


### PR DESCRIPTION
An alternative solution for the data alignment proposed in that [PR](https://github.com/msgpack/msgpack-javascript/pull/245)

In that proposal, the `encode` function of the extension codec could return a function that will be called by `Encoder` at the moment of building the final buffer. The function receives the position of the data in the buffer. The encoder expects to receive data that will be then added to the buffer at the provided position. Users can add the padding bytes straight into the data at the encoding phase and calculate the data offset at the decoding phase depending on the chosen padding+data format.

That solution has some advantages over the one mentioned above. 
- It doesn't change the message pack format. The padding "lives" in the data part.
- It allows a user to decide how to align the data.
- It doesn't break the compatibility with the existing formats.

The drawback is that to resolve the ambiguity of the final size of the data the size field always takes 4 bytes, independent of how big the actual data is. That could be highlighted in the documentation to warn users. That is only a deal in case of returning a function instead of the actual data from the `encode` function, so the existing users won't be affected.