### PR TITLE
add a regression test based on #195

### DIFF
--- a/test/reuse-instances-with-extensions.test.ts
+++ b/test/reuse-instances-with-extensions.test.ts
@@ -21,8 +21,8 @@ class MsgPackContext {
   readonly extensionCodec = new ExtensionCodec<MsgPackContext>();
 
   constructor() {
-    const encoder = new Encoder<MsgPackContext>({ extensionCodec: this.extensionCodec, context: this });
-    const decoder = new Decoder<MsgPackContext>({ extensionCodec: this.extensionCodec, context: this });
+    const encoder = new Encoder({ extensionCodec: this.extensionCodec, context: this });
+    const decoder = new Decoder({ extensionCodec: this.extensionCodec, context: this });
 
     this.encode = encoder.encode.bind(encoder);
     this.decode = decoder.decode.bind(decoder);
@@ -37,5 +37,12 @@ describe("reuse instances with extensions", () => {
     const buf = context.encode(BigInt(42));
     const data = context.decode(buf);
     deepStrictEqual(data, BigInt(42));
+  });
+
+  it("should encode and decode bigints", () => {
+    const context = new MsgPackContext();
+    const buf = context.encode([BigInt(1), BigInt(2), BigInt(3)]);
+    const data = context.decode(buf);
+    deepStrictEqual(data, [BigInt(1), BigInt(2), BigInt(3)]);
   });
 });

--- a/test/reuse-instances-with-extensions.test.ts
+++ b/test/reuse-instances-with-extensions.test.ts
@@ -1,0 +1,41 @@
+// https://github.com/msgpack/msgpack-javascript/issues/195
+
+import { deepStrictEqual } from "assert";
+import { Encoder, Decoder, ExtensionCodec } from "../src/index";
+
+const MSGPACK_EXT_TYPE_BIGINT = 0;
+
+function registerCodecs(context: MsgPackContext) {
+  const { extensionCodec, encode, decode } = context;
+
+  extensionCodec.register({
+    type: MSGPACK_EXT_TYPE_BIGINT,
+    encode: (value) => (typeof value === "bigint" ? encode(value.toString()) : null),
+    decode: (data) => BigInt(decode(data) as string),
+  });
+}
+
+class MsgPackContext {
+  readonly encode: (value: unknown) => Uint8Array;
+  readonly decode: (buffer: BufferSource | ArrayLike<number>) => unknown;
+  readonly extensionCodec = new ExtensionCodec<MsgPackContext>();
+
+  constructor() {
+    const encoder = new Encoder<MsgPackContext>({ extensionCodec: this.extensionCodec, context: this });
+    const decoder = new Decoder<MsgPackContext>({ extensionCodec: this.extensionCodec, context: this });
+
+    this.encode = encoder.encode.bind(encoder);
+    this.decode = decoder.decode.bind(decoder);
+
+    registerCodecs(this);
+  }
+}
+
+describe("reuse instances with extensions", () => {
+  it("should encode and decode a bigint", () => {
+    const context = new MsgPackContext();
+    const buf = context.encode(BigInt(42));
+    const data = context.decode(buf);
+    deepStrictEqual(data, BigInt(42));
+  });
+});

--- a/tsconfig.dist.es5+esm.json
+++ b/tsconfig.dist.es5+esm.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "target": "es5",
     "module": "es2015",
+    "downlevelIteration": true,
     "outDir": "./dist.es5+esm",
     "declaration": false,
     "noEmitOnError": true,


### PR DESCRIPTION
close #195

```
$ npx mocha test/reuse-instances-with-extensions.test.ts


  reuse instances with extensions
    1) should encode and decode a bigint


  0 passing (5ms)
  1 failing

  1) reuse instances with extensions
       should encode and decode a bigint:
     RangeError: Extra 6 of 9 byte(s) found at buffer[3]
      at Decoder.createExtraByteError (src/Decoder.ts:274:12)
      at Decoder.decode (src/Decoder.ts:287:18)
      at Context.<anonymous> (test/reuse-instances-with-extensions.test.ts:38:26)
      at processImmediate (node:internal/timers:491:21)
```