### PR TITLE
adding support for nonstandard map key in the decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,17 +145,20 @@ NodeJS `Buffer` is also acceptable because it is a subclass of `Uint8Array`.
 
 #### `DecoderOptions`
 
-| Name           | Type           | Default                       |
-| -------------- | -------------- | ----------------------------- |
-| extensionCodec | ExtensionCodec | `ExtensionCodec.defaultCodec` |
-| context        | user-defined   | -                             |
-| useBigInt64    | boolean        | false                         |
-| rawStrings     | boolean        | false                         |
-| maxStrLength   | number         | `4_294_967_295` (UINT32_MAX)  |
-| maxBinLength   | number         | `4_294_967_295` (UINT32_MAX)  |
-| maxArrayLength | number         | `4_294_967_295` (UINT32_MAX)  |
-| maxMapLength   | number         | `4_294_967_295` (UINT32_MAX)  |
-| maxExtLength   | number         | `4_294_967_295` (UINT32_MAX)  |
+| Name            | Type                | Default                                        |
+| --------------- | ------------------- | ---------------------------------------------- |
+| extensionCodec  | ExtensionCodec      | `ExtensionCodec.defaultCodec`                  |
+| context         | user-defined        | -                                              |
+| useBigInt64     | boolean             | false                                          |
+| rawStrings      | boolean             | false                                          |
+| maxStrLength    | number              | `4_294_967_295` (UINT32_MAX)                   |
+| maxBinLength    | number              | `4_294_967_295` (UINT32_MAX)                   |
+| maxArrayLength  | number              | `4_294_967_295` (UINT32_MAX)                   |
+| maxMapLength    | number              | `4_294_967_295` (UINT32_MAX)                   |
+| maxExtLength    | number              | `4_294_967_295` (UINT32_MAX)                   |
+| mapKeyConverter | MapKeyConverterType | throw exception if key is not string or number |
+
+`MapKeyConverterType` is defined as `(key: unknown) => string | number`.
 
 To skip UTF-8 decoding of strings, `rawStrings` can be set to `true`. In this case, strings are decoded into `Uint8Array`.
 

--- a/test/decodeAsync.test.ts
+++ b/test/decodeAsync.test.ts
@@ -36,6 +36,21 @@ describe("decodeAsync", () => {
     assert.deepStrictEqual(object, { "foo": "bar" });
   });
 
+  it("decodes fixmap {'[1, 2]': 'baz'} with custom map key converter", async () => {
+    const createStream = async function* () {
+      yield [0x81]; // fixmap size=1
+      yield encode([1, 2]);
+      yield encode("baz");
+    };
+
+    const object = await decodeAsync(createStream(), {
+      mapKeyConverter: (key) => JSON.stringify(key),
+    });
+
+    const key = JSON.stringify([1, 2]);
+    assert.deepStrictEqual(object, { [key]: "baz" });
+  });
+
   it("decodes multi-byte integer byte-by-byte", async () => {
     const createStream = async function* () {
       yield [0xcd]; // uint 16


### PR DESCRIPTION
Adding support for nonstandard map key in the decoder by adding a new callback function in the decoder options that accepts the decoded map key and returns a JS standard map key (string or number)

fix #255 