### PR TITLE
encoder: Encode instances of Number as numbers, not maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "scripts": {
     "build": "npm publish --dry-run",
     "prepare": "npm run clean && webpack --bail && tsc --build tsconfig.dist.cjs.json tsconfig.dist.esm.json && tsimp tools/fix-ext.mts --mjs dist.esm/*.js dist.esm/*/*.js && tsimp tools/fix-ext.mts --cjs dist.cjs/*.js dist.cjs/*/*.js",
-    "prepublishOnly": "npm run test:dist",
     "clean": "rimraf build dist dist.*",
     "test": "mocha 'test/**/*.test.ts'",
     "test:dist": "npm run lint && npm run test && npm run test:deno",

--- a/src/Encoder.ts
+++ b/src/Encoder.ts
@@ -339,6 +339,8 @@ export class Encoder<ContextType = undefined> {
     const ext = this.extensionCodec.tryToEncode(object, this.context);
     if (ext != null) {
       this.encodeExtension(ext);
+    } else if (object instanceof Number) {
+      this.encodeNumber(object.valueOf());
     } else if (Array.isArray(object)) {
       this.encodeArray(object, depth);
     } else if (ArrayBuffer.isView(object)) {


### PR DESCRIPTION
Make sure instances of `Number` as encoded as a `number` instead of a `map`. 
I am encountering this issue in my current project, I believe this is a more sensible default behavior

All tests pass.