### PR TITLE
fix: throw when encoding a BigInt outside int64/uint64 range

### DIFF
--- a/src/Encoder.ts
+++ b/src/Encoder.ts
@@ -72,6 +72,10 @@ export type EncoderOptions<ContextType = undefined> = Partial<
 > &
   ContextOf<ContextType>;
 
+// Bounds of the int64/uint64 range msgpack can represent, precomputed once for encodeBigInt64.
+const INT64_MIN = -(BigInt(2) ** BigInt(63));
+const UINT64_MAX = BigInt(2) ** BigInt(64) - BigInt(1);
+
 export class Encoder<ContextType = undefined> {
   private readonly extensionCodec: ExtensionCodecType<ContextType>;
   private readonly context: ContextType;
@@ -291,7 +295,7 @@ export class Encoder<ContextType = undefined> {
   }
 
   private encodeBigInt64(object: bigint): void {
-    if (object < -(BigInt(2) ** BigInt(63)) || object > BigInt(2) ** BigInt(64) - BigInt(1)) {
+    if (object < INT64_MIN || object > UINT64_MAX) {
       throw new Error(`Cannot encode BigInt as int64/uint64 because it is out of range: ${object}`);
     }
     if (object >= BigInt(0)) {

--- a/src/Encoder.ts
+++ b/src/Encoder.ts
@@ -291,6 +291,9 @@ export class Encoder<ContextType = undefined> {
   }
 
   private encodeBigInt64(object: bigint): void {
+    if (object < -(BigInt(2) ** BigInt(63)) || object > BigInt(2) ** BigInt(64) - BigInt(1)) {
+      throw new Error(`Cannot encode BigInt as int64/uint64 because it is out of range: ${object}`);
+    }
     if (object >= BigInt(0)) {
       // uint 64
       this.writeU8(0xcf);

--- a/test/bigint64.test.ts
+++ b/test/bigint64.test.ts
@@ -35,4 +35,30 @@ describe("useBigInt64: true", () => {
     const encoded = encode(value, { useBigInt64: true });
     assert.deepStrictEqual(decode(encoded, { useBigInt64: true }), value);
   });
+
+  it("round-trips the boundary values of int64/uint64", () => {
+    const values = [
+      BigInt(0),
+      BigInt(42),
+      BigInt(2) ** BigInt(63) - BigInt(1), // max int64
+      -(BigInt(2) ** BigInt(63)), // min int64
+      BigInt(2) ** BigInt(64) - BigInt(1), // max uint64
+    ];
+    for (const value of values) {
+      const encoded = encode(value, { useBigInt64: true });
+      assert.deepStrictEqual(decode(encoded, { useBigInt64: true }), value);
+    }
+  });
+
+  it("throws when a bigint is out of the int64/uint64 range", () => {
+    const values = [
+      BigInt(2) ** BigInt(64), // uint64 max + 1
+      BigInt(2) ** BigInt(64) + BigInt(1),
+      -(BigInt(2) ** BigInt(63)) - BigInt(1), // int64 min - 1
+      -(BigInt(2) ** BigInt(100)),
+    ];
+    for (const value of values) {
+      assert.throws(() => encode(value, { useBigInt64: true }), /out of range/);
+    }
+  });
 });


### PR DESCRIPTION
## Problem

With `useBigInt64: true`, `encodeBigInt64` branches only on the sign of the value and calls the native `DataView.setBigUint64` / `setBigInt64`. Those methods truncate the value mod 2^64 instead of throwing, so a `BigInt` outside the representable range is silently corrupted on encode:

```js
import { encode, decode } from "@msgpack/msgpack";

decode(encode(2n ** 64n,         { useBigInt64: true }), { useBigInt64: true }); // 0n
decode(encode(2n ** 64n + 1n,    { useBigInt64: true }), { useBigInt64: true }); // 1n
decode(encode(-(2n ** 63n) - 1n, { useBigInt64: true }), { useBigInt64: true }); // 9223372036854775807n  (sign flip)
decode(encode(-(2n ** 100n),     { useBigInt64: true }), { useBigInt64: true }); // 0n
```

No error is raised, so the caller has no way to notice the data loss.

## Fix

The MessagePack int family is fixed 64-bit, so the only representable range for a `BigInt` is the union of signed int64 and unsigned uint64: `[-2^63, 2^64 - 1]`. This adds a range check in `encodeBigInt64` that throws for anything outside that range, before the writes.

This matches how the encoder already rejects other unrepresentable inputs (too-long strings, too-large arrays/maps/binaries all throw rather than emit corrupt bytes).

## Tests

Extended `test/bigint64.test.ts`:
- the four out-of-range cases above now throw
- the boundary values still round-trip: `0n`, `42n`, `2n ** 63n - 1n` (max int64), `-(2n ** 63n)` (min int64), `2n ** 64n - 1n` (max uint64)

Full suite: 329 passing, lint clean.