### PR TITLE
fix(decode): preserve mapKeyConverter in Decoder#clone()

### DIFF
--- a/src/Decoder.ts
+++ b/src/Decoder.ts
@@ -264,6 +264,7 @@ export class Decoder<ContextType = undefined> {
       maxMapLength: this.maxMapLength,
       maxExtLength: this.maxExtLength,
       keyDecoder: this.keyDecoder,
+      mapKeyConverter: this.mapKeyConverter,
     } as any);
   }
 

--- a/test/reuse-instances-with-extensions.test.ts
+++ b/test/reuse-instances-with-extensions.test.ts
@@ -45,4 +45,31 @@ describe("reuse instances with extensions", () => {
     const data = context.decode(buf);
     deepStrictEqual(data, [BigInt(1), BigInt(2), BigInt(3)]);
   });
+
+  it("keeps mapKeyConverter for maps decoded re-entrantly inside an extension", () => {
+    const MSGPACK_EXT_TYPE_WRAP = 1;
+    const extensionCodec = new ExtensionCodec();
+    const encoder = new Encoder({ extensionCodec });
+    const decoder = new Decoder({ extensionCodec, mapKeyConverter: (key) => String(key).toUpperCase() });
+
+    class Wrapped {
+      readonly inner: unknown;
+      constructor(inner: unknown) {
+        this.inner = inner;
+      }
+    }
+    extensionCodec.register({
+      type: MSGPACK_EXT_TYPE_WRAP,
+      encode: (value) => (value instanceof Wrapped ? encoder.encode(value.inner) : null),
+      // decode re-enters the same decoder instance, which triggers Decoder#clone()
+      decode: (data) => new Wrapped(decoder.decode(data)),
+    });
+
+    const buf = encoder.encode({ a: 1, nested: new Wrapped({ b: 2 }) });
+    const decoded = decoder.decode(buf) as Record<string, Wrapped>;
+
+    // The nested map is decoded on the cloned decoder; it must use the same converter.
+    deepStrictEqual(Object.keys(decoded), ["A", "NESTED"]);
+    deepStrictEqual(decoded["NESTED"]!.inner, { B: 2 });
+  });
 });


### PR DESCRIPTION
## Problem

`Decoder#clone()` is used for re-entrant decoding — for example an extension codec that decodes nested MessagePack on the same reusable `Decoder` instance (the pattern from #195). `clone()` copies every decoder option except `mapKeyConverter`, so any map decoded re-entrantly silently falls back to the default key converter instead of the one the caller configured.

Repro (converter upper-cases keys; extension type 1 re-enters the same decoder):

```js
const decoder = new Decoder({ extensionCodec, mapKeyConverter: (k) => String(k).toUpperCase() });
// extension type 1 decode: (data) => new Wrapped(decoder.decode(data))
const out = decoder.decode(encoder.encode({ a: 1, nested: new Wrapped({ b: 2 }) }));
// top-level keys: ["A", "NESTED"]   (converter applied)
// out.NESTED.inner keys: ["b"]      (converter dropped — should be ["B"])
```

## Fix

Copy `mapKeyConverter` in `clone()` alongside the other options (`keyDecoder` and the `max*` limits are already copied). One line, plus a regression test that decodes a nested map through an extension codec.

Full suite: 328 passing; lint and typecheck clean.
